### PR TITLE
Installer: Remove references to the <DBPREFIX>settings table

### DIFF
--- a/installer/config/config.php
+++ b/installer/config/config.php
@@ -138,6 +138,7 @@ $arrFiles = array(
 );
 
 $arrDatabaseTables = array(
+// TODO: Either update, or remove this outdated and incomplete list.
     'module_block_blocks',
     'module_block_rel_pages',
     'module_block_settings',
@@ -174,7 +175,6 @@ $arrDatabaseTables = array(
     'modules',
     'module_repository',
     'sessions',
-    'settings',
     'settings_smtp',
     'skins',
     'module_directory_categories',


### PR DESCRIPTION
Apparently, the settings table is no longer present in the structure SQL dump.
This broke the installer when verifying the tables present in the database, as the table name was still listed in the installer configuration file.
Note the TODO about the domainURL setting, the configureCaching() method, and the settings.php file itself in the _createSettingsFile() method.