### PR TITLE
Apply the current port number to the settings during installation

### DIFF
--- a/core/Config/Controller/Config.class.php
+++ b/core/Config/Controller/Config.class.php
@@ -1196,14 +1196,24 @@ class Config
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for Protocol In Use");
             }            
             if (!\Cx\Core\Setting\Controller\Setting::isDefined('portFrontendHTTP')
-                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTP',80, 1,
-                \Cx\Core\Setting\Controller\Setting::TYPE_TEXT, null, 'site')){
+                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTP',
+                    (isset($existingConfig['portFrontendHTTP'])
+                        ? $existingConfig['portFrontendHTTP']
+                        : ($_SERVER["HTTPS"] === 'on'
+                            ? 80 : $_SERVER['SERVER_PORT'])),
+                    1, \Cx\Core\Setting\Controller\Setting::TYPE_TEXT,
+                    null, 'site')) {
                     \DBG::log("Failed to add Setting entry for core HTTP Port (Frontend)");
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for core HTTP Port (Frontend)");
             }
             if (!\Cx\Core\Setting\Controller\Setting::isDefined('portFrontendHTTPS')
-                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTPS',443, 1,
-                \Cx\Core\Setting\Controller\Setting::TYPE_TEXT, null, 'site')){
+                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTPS',
+                    (isset($existingConfig['portFrontendHTTPS'])
+                        ? $existingConfig['portFrontendHTTPS']
+                        : ($_SERVER["HTTPS"] === 'on'
+                            ? $_SERVER['SERVER_PORT'] : 443)),
+                    1, \Cx\Core\Setting\Controller\Setting::TYPE_TEXT,
+                    null, 'site')) {
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for core HTTPS Port (Frontend)");
             }
 

--- a/installer/config/config.php
+++ b/installer/config/config.php
@@ -138,6 +138,7 @@ $arrFiles = array(
 );
 
 $arrDatabaseTables = array(
+// TODO: Either update, or remove this outdated and incomplete list.
     'module_block_blocks',
     'module_block_rel_pages',
     'module_block_settings',
@@ -174,7 +175,6 @@ $arrDatabaseTables = array(
     'modules',
     'module_repository',
     'sessions',
-    'settings',
     'settings_smtp',
     'skins',
     'module_directory_categories',


### PR DESCRIPTION
Detect which protocol (HTTP or HTTPS) is used during installation, and apply the current port number to the respective setting.
The other protocol is presumed to use the default port, which can be changed in the settings later.
