### PR TITLE
Various: Fix PHP notices about missing language entries

### DIFF
--- a/core/Config/Controller/Config.class.php
+++ b/core/Config/Controller/Config.class.php
@@ -1196,14 +1196,24 @@ class Config
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for Protocol In Use");
             }            
             if (!\Cx\Core\Setting\Controller\Setting::isDefined('portFrontendHTTP')
-                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTP',80, 1,
-                \Cx\Core\Setting\Controller\Setting::TYPE_TEXT, null, 'site')){
+                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTP',
+                    (isset($existingConfig['portFrontendHTTP'])
+                        ? $existingConfig['portFrontendHTTP']
+                        : ($_SERVER["HTTPS"] === 'on'
+                            ? 80 : $_SERVER['SERVER_PORT'])),
+                    1, \Cx\Core\Setting\Controller\Setting::TYPE_TEXT,
+                    null, 'site')) {
                     \DBG::log("Failed to add Setting entry for core HTTP Port (Frontend)");
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for core HTTP Port (Frontend)");
             }
             if (!\Cx\Core\Setting\Controller\Setting::isDefined('portFrontendHTTPS')
-                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTPS',443, 1,
-                \Cx\Core\Setting\Controller\Setting::TYPE_TEXT, null, 'site')){
+                && !\Cx\Core\Setting\Controller\Setting::add('portFrontendHTTPS',
+                    (isset($existingConfig['portFrontendHTTPS'])
+                        ? $existingConfig['portFrontendHTTPS']
+                        : ($_SERVER["HTTPS"] === 'on'
+                            ? $_SERVER['SERVER_PORT'] : 443)),
+                    1, \Cx\Core\Setting\Controller\Setting::TYPE_TEXT,
+                    null, 'site')) {
                     throw new \Cx\Lib\Update_DatabaseException("Failed to add Setting entry for core HTTPS Port (Frontend)");
             }
 

--- a/core/Core/Controller/Cx.class.php
+++ b/core/Core/Controller/Cx.class.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,7 +24,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * Main script for Cloudrexx
  * @copyright   CLOUDREXX CMS - CLOUDREXX AG
@@ -563,7 +563,7 @@ namespace Cx\Core\Core\Controller {
         protected $websiteImagesAccessProfileWebPath;
         protected $websiteImagesAccessPhotoPath;
         protected $websiteImagesAccessPhotoWebPath;
-        
+
         /**
          * @var \Cx\Core\MediaSource\Model\Entity\MediaSourceManager
          */
@@ -712,7 +712,7 @@ namespace Cx\Core\Core\Controller {
                  * Loads all active components
                  */
                 $this->loadComponents();
-                
+
                 /**
                  * Since we have a valid state now, we can start executing
                  * all of the component's hook methods.
@@ -1078,7 +1078,7 @@ namespace Cx\Core\Core\Controller {
         /**
          * Calls pre-init hooks
          * Pre-Init hooks are defined in /config/preInitHooks.yml.
-         * 
+         *
          * @throws \Exception
          */
         protected function callPreInitHooks() {
@@ -1097,7 +1097,7 @@ namespace Cx\Core\Core\Controller {
         /**
          * Calls post-init hooks
          * Post-Init hooks are defined in /config/postInitHooks.yml.
-         * 
+         *
          * @throws \Exception
          */
         protected function callPostInitHooks() {
@@ -1113,14 +1113,14 @@ namespace Cx\Core\Core\Controller {
             }
         }
 
-        
+
         /**
          * Get component controller object by given component name and type
          * Calls before the method preInit() and postInit() hooks are called
-         * 
+         *
          * @param string $componentName component name
          * @param string $componentType component type
-         * 
+         *
          * @return \Cx\Core\Core\Controller\SystemComponentController
          */
         protected function getComponentControllerByNameAndType($componentName, $componentType)
@@ -1140,7 +1140,7 @@ namespace Cx\Core\Core\Controller {
             }
             return new $componentControllerClass($component, $this);
         }
-        
+
         /**
          * This tries to set the memory limit if its lower than 32 megabytes
          */
@@ -1410,7 +1410,7 @@ namespace Cx\Core\Core\Controller {
                     }
 
                     $objCommand = $this->commands[$command];
-                    //Check the access permission for the command.                    
+                    //Check the access permission for the command.
                     if(!$objCommand->hasAccessToExecuteCommand($command, $params)) {
                         throw new \Exception('The command ' . $command . ' has been rejected by not complying to the permission requirements of the requested method.');
                     }
@@ -1420,7 +1420,7 @@ namespace Cx\Core\Core\Controller {
                 } catch (\Exception $e) {
                     throw new \Exception($e);
                 }
-                
+
             }
             // init template
             $this->loadTemplate();                      // Sigma Template
@@ -2109,7 +2109,16 @@ namespace Cx\Core\Core\Controller {
                     'CX_VERSION'       => $_CONFIG['coreCmsVersion'],
                     'CX_CODE_NAME'     => $_CONFIG['coreCmsCodeName'],
                     'CX_STATUS'        => $_CONFIG['coreCmsStatus'],
-                    'CX_RELEASE_DATE'  => date(ASCMS_DATE_FORMAT_DATE, $_CONFIG['coreCmsReleaseDate']),
+// TODO: Store the date in normalized form
+// (either as timestamp (yuck), or DATE, "yyyy-mm-dd" (somewhat yucky),
+// or as a proper Date and timezone).
+// The release date is actually present as "17.12.2014" in my config.yml file!
+                    'CX_RELEASE_DATE'  => date(ASCMS_DATE_FORMAT_DATE,
+                        (intval($_CONFIG['coreCmsReleaseDate'])
+                         == $_CONFIG['coreCmsReleaseDate']
+                            ? $_CONFIG['coreCmsReleaseDate']
+                            : strtotime($_CONFIG['coreCmsReleaseDate']))
+                    ),
                     'CX_NAME'          => $_CONFIG['coreCmsName'],
                 ));
 
@@ -2570,7 +2579,7 @@ namespace Cx\Core\Core\Controller {
             $this->websiteMediaMarketPath       = $this->websiteDocumentRootPath . self::FOLDER_NAME_MEDIA . '/Market';
             $this->websiteMediaCrmPath          = $this->websiteDocumentRootPath . self::FOLDER_NAME_MEDIA . '/Crm';
             $this->websiteMediaDirectoryPath    = $this->websiteDocumentRootPath . self::FOLDER_NAME_MEDIA . '/Directory';
-            
+
             $this->websiteImagesContentWebPath  = $this->websiteOffsetPath . self::FOLDER_NAME_IMAGES . '/content';
             $this->websiteImagesAttachWebPath   = $this->websiteOffsetPath . self::FOLDER_NAME_IMAGES . '/attach';
             $this->websiteImagesShopWebPath     = $this->websiteOffsetPath . self::FOLDER_NAME_IMAGES . '/Shop';
@@ -2594,7 +2603,7 @@ namespace Cx\Core\Core\Controller {
             $this->websiteMediaFileSharingWebPath=$this->websiteOffsetPath . self::FOLDER_NAME_MEDIA . '/FileSharing';
             $this->websiteMediaMarketWebPath     = $this->websiteOffsetPath . self::FOLDER_NAME_MEDIA . '/Market';
             $this->websiteMediaDirectoryWebPath  = $this->websiteOffsetPath . self::FOLDER_NAME_MEDIA . '/Directory';
-                        
+
             $this->websitePublicTempPath        = $this->websiteTempPath    . self::FOLDER_NAME_PUBLIC_TEMP;
             $this->websitePublicTempWebPath     = $this->websiteTempWebPath . self::FOLDER_NAME_PUBLIC_TEMP;
         }
@@ -3045,7 +3054,7 @@ namespace Cx\Core\Core\Controller {
         public function getWebsitePublicTempWebPath() {
             return $this->websitePublicTempWebPath;
         }
-        
+
          /**
          * Return the absolute path to the website's data repository to the
          * location of the /images/Crm
@@ -3126,7 +3135,7 @@ namespace Cx\Core\Core\Controller {
         public function getWebsiteImagesAccessPhotoPath() {
             return $this->websiteImagesAccessPhotoPath;
         }
-        
+
         /**
          * Return the offset path to the data repository of the access photo.
          * Formerly known as ASCMS_ACCESS_PHOTO_IMG_WEB_PATH.

--- a/core/ViewManager/Model/Event/ViewManagerEventListener.class.php
+++ b/core/ViewManager/Model/Event/ViewManagerEventListener.class.php
@@ -52,12 +52,14 @@ class ViewManagerEventListener extends DefaultEventListener
     public function mediasourceLoad(MediaSourceManager $mediaSourceManager)
     {
         global $_ARRAYLANG;
-        $mediaType = new MediaSource(
-            'themes', $_ARRAYLANG['TXT_THEME_THEMES'],
+        \Env::get('init')->loadLanguageData('ViewManager');
+        $mediaType = new MediaSource('themes',
+            $_ARRAYLANG['TXT_THEME_THEMES'],
             array(
                 $this->cx->getWebsiteThemesPath(),
                 $this->cx->getWebsiteThemesWebPath(),
-            ), array(), '',
+            ),
+            array(), '',
             new ViewManagerFileSystem($this->cx->getWebsiteThemesPath())
         );
         $mediaSourceManager->addMediaType($mediaType);

--- a/core/ViewManager/lang/de/frontend.php
+++ b/core/ViewManager/lang/de/frontend.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Cloudrexx
+ *
+ * @link      http://www.cloudrexx.com
+ * @copyright Cloudrexx AG 2007-2015
+ *
+ * According to our dual licensing model, this program can be used either
+ * under the terms of the GNU Affero General Public License, version 3,
+ * or under a proprietary license.
+ *
+ * The texts of the GNU Affero General Public License with an additional
+ * permission and of our proprietary license can be found at and
+ * in the LICENSE file you have received along with this program.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * "Cloudrexx" is a registered trademark of Cloudrexx AG.
+ * The licensing of the program under the AGPLv3 does not imply a
+ * trademark license. Therefore any rights, title and interest in
+ * our trademarks remain entirely with us.
+ */
+
+/**
+ * @copyright   CLOUDREXX CMS - CLOUDREXX AG
+ * @author      Cloudrexx Development Team <info@cloudrexx.com>
+ * @access      public
+ * @package     cloudrexx
+ * @subpackage  core_viewmanager
+ */
+global $_ARRAYLANG;
+
+// TODO: Verify the content of this entry.
+// TODO: The entry may be missing in the backend.
+// TODO: Add the entry to other languages.
+$_ARRAYLANG['TXT_THEME_THEMES'] = 'Design';

--- a/core_modules/Access/Model/Event/AccessEventListener.class.php
+++ b/core_modules/Access/Model/Event/AccessEventListener.class.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,7 +24,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * Class AccessEventListener
  *
@@ -62,7 +62,7 @@ class AccessEventListener extends DefaultEventListener
         global $_ARRAYLANG;
         $mediaType = new MediaSource(
             'access',
-            $_ARRAYLANG['TXT_USER_ADMINISTRATION'],
+            $_ARRAYLANG['TXT_ACCESS_USER_ADMINISTRATION'],
             array(
                 $this->cx->getWebsiteImagesAccessPath(),
                 $this->cx->getWebsiteImagesAccessWebPath(),

--- a/core_modules/Access/lang/de/frontend.php
+++ b/core_modules/Access/lang/de/frontend.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,7 +24,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * @copyright   CLOUDREXX CMS - CLOUDREXX AG
  * @author      Cloudrexx Development Team <info@cloudrexx.com>
@@ -120,3 +120,8 @@ $_ARRAYLANG['TXT_ACCESS_SOCIALLOGIN_CONNECT'] = "Verbinden";
 $_ARRAYLANG['TXT_ACCESS_SOCIALLOGIN_CONNECTED'] = "verbunden";
 $_ARRAYLANG['TXT_ACCESS_SOCIALLOGIN_DISCONNECT'] = "Trennen";
 $_ARRAYLANG['TXT_ACCESS_SOCIALLOGIN_DISCONNECTED'] = "getrennt";
+
+// TODO: Verify the content of this entry.
+// TODO: The entry may be missing in the backend.
+// TODO: Add the entry to other languages.
+$_ARRAYLANG['TXT_ACCESS_USER_ADMINISTRATION'] = 'Benutzerverwaltung';

--- a/installer/config/config.php
+++ b/installer/config/config.php
@@ -138,6 +138,7 @@ $arrFiles = array(
 );
 
 $arrDatabaseTables = array(
+// TODO: Either update, or remove this outdated and incomplete list.
     'module_block_blocks',
     'module_block_rel_pages',
     'module_block_settings',
@@ -174,7 +175,6 @@ $arrDatabaseTables = array(
     'modules',
     'module_repository',
     'sessions',
-    'settings',
     'settings_smtp',
     'skins',
     'module_directory_categories',

--- a/modules/Blog/Model/Event/BlogEventListener.class.php
+++ b/modules/Blog/Model/Event/BlogEventListener.class.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,7 +24,7 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * Class BlogEventListener
  *
@@ -52,10 +52,15 @@ class BlogEventListener extends DefaultEventListener {
     public function mediasourceLoad(MediaSourceManager $mediaBrowserConfiguration)
     {
         global $_ARRAYLANG;
-        $mediaType = new MediaSource('blog',$_ARRAYLANG['TXT_BLOG_MODULE'],array(
-            $this->cx->getWebsiteImagesBlogPath(),
-            $this->cx->getWebsiteImagesBlogWebPath(),
-        ),array(119));
+        \Env::get('init')->loadLanguageData('Blog');
+        $mediaType = new MediaSource('blog',
+            $_ARRAYLANG['TXT_MODULE_BLOG'],
+            array(
+                $this->cx->getWebsiteImagesBlogPath(),
+                $this->cx->getWebsiteImagesBlogWebPath(),
+            ),
+            array(119)
+        );
         $mediaBrowserConfiguration->addMediaType($mediaType);
     }
 

--- a/modules/Blog/lang/de/frontend.php
+++ b/modules/Blog/lang/de/frontend.php
@@ -81,4 +81,8 @@ $_ARRAYLANG['TXT_BLOG_LIB_RATING'] = "Bewertung";
 $_ARRAYLANG['TXT_BLOG_LIB_ALL_CATEGORIES'] = "Alle Kategorien";
 $_ARRAYLANG['TXT_BLOG_LIB_RSS_MESSAGES_TITLE'] = "Blog Meldungen";
 $_ARRAYLANG['TXT_BLOG_LIB_RSS_COMMENTS_TITLE'] = "Blog Kommentare";
-?>
+
+// TODO: Verify the content of this entry.
+// TODO: The entry may be missing in the backend.
+// TODO: Add the entry to other languages.
+$_ARRAYLANG['TXT_MODULE_BLOG'] = 'Blog';

--- a/modules/Calendar/Model/Event/CalendarEventListener.class.php
+++ b/modules/Calendar/Model/Event/CalendarEventListener.class.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,10 +24,10 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * EventListener for Calendar
- * 
+ *
  * @copyright   Cloudrexx AG
  * @author      Project Team SS4U <info@cloudrexx.com>
  * @package     cloudrexx
@@ -41,14 +41,14 @@ use Cx\Core\Event\Model\Entity\DefaultEventListener;
 
 /**
  * EventListener for Calendar
- * 
+ *
  * @copyright   Cloudrexx AG
  * @author      Project Team SS4U <info@cloudrexx.com>
  * @package     cloudrexx
  * @subpackage  module_calendar
  */
 class CalendarEventListener extends DefaultEventListener {
-   
+
     public function SearchFindContent($search) {
         $term_db = $search->getTerm();
         $query = \Cx\Modules\Calendar\Controller\CalendarEvent::getEventSearchQuery($term_db);
@@ -62,10 +62,15 @@ class CalendarEventListener extends DefaultEventListener {
     public function mediasourceLoad(MediaSourceManager $mediaBrowserConfiguration)
     {
         global $_ARRAYLANG;
-        $mediaType = new MediaSource('calendar',$_ARRAYLANG['TXT_CALENDAR'],array(
-            $this->cx->getWebsiteImagesCalendarPath(),
-            $this->cx->getWebsiteImagesCalendarWebPath(),
-        ),array(16));
+        \Env::get('init')->loadLanguageData('Calendar');
+        $mediaType = new MediaSource('calendar',
+            $_ARRAYLANG['TXT_CALENDAR'],
+            array(
+                $this->cx->getWebsiteImagesCalendarPath(),
+                $this->cx->getWebsiteImagesCalendarWebPath(),
+            ),
+            array(16)
+        );
         $mediaBrowserConfiguration->addMediaType($mediaType);
     }
 }

--- a/modules/Calendar/lang/de/frontend.php
+++ b/modules/Calendar/lang/de/frontend.php
@@ -5,7 +5,7 @@
  *
  * @link      http://www.cloudrexx.com
  * @copyright Cloudrexx AG 2007-2015
- * 
+ *
  * According to our dual licensing model, this program can be used either
  * under the terms of the GNU Affero General Public License, version 3,
  * or under a proprietary license.
@@ -24,10 +24,10 @@
  * trademark license. Therefore any rights, title and interest in
  * our trademarks remain entirely with us.
  */
- 
+
 /**
  * Calendar Language variables
- * 
+ *
  * @package    cloudrexx
  * @subpackage module_calendar
  * @author     Cloudrexx <info@cloudrexx.com>
@@ -47,7 +47,7 @@ $_ARRAYLANG['TXT_CALENDAR_NAME'] = "Betreff";
 $_ARRAYLANG['TXT_CALENDAR_PLACE'] = "Ort";
 $_ARRAYLANG['TXT_CALENDAR_PRIORITY'] = "Priorität";
 $_ARRAYLANG['TXT_CALENDAR_START'] = "Beginnt um";
-$_ARRAYLANG['TXT_CALENDAR_END'] = "Endet um";                     
+$_ARRAYLANG['TXT_CALENDAR_END'] = "Endet um";
 $_ARRAYLANG['TXT_CALENDAR_INFO'] = "Link";
 $_ARRAYLANG['TXT_CALENDAR_SEARCH'] = "Suchen";
 $_ARRAYLANG['TXT_ENDDATE'] = "Bis:";
@@ -63,7 +63,7 @@ $_ARRAYLANG['TXT_CALENDAR_DAY_ARRAY'] = "So,Mo,Di,Mi,Do,Fr,Sa";
 $_ARRAYLANG['TXT_CALENDAR_EXPORT_ICAL'] = "Aktuelle Kategorie als iCalendar-Datei exportieren";
 $_ARRAYLANG['TXT_CALENDAR_EXPORT_ICAL_ALL'] = "Alle Termine als iCalendar-Datei exportieren";
 $_ARRAYLANG['TXT_CALENDAR_EXPORT_ICAL_EVENT'] = "Diese Veranstaltung exportieren";
-$_ARRAYLANG['TXT_CALENDAR_TERMIN'] = "Termin";  
+$_ARRAYLANG['TXT_CALENDAR_TERMIN'] = "Termin";
 $_ARRAYLANG['TXT_CALENDAR_ORGANIZER'] = "Veranstalter";
 $_ARRAYLANG['TXT_CALENDAR_OPTIONS'] = "Zusätzliche Angaben";
 $_ARRAYLANG['TXT_CALENDAR_THUMBNAIL'] = "Bild";
@@ -130,12 +130,12 @@ $_ARRAYLANG['TXT_CALENDAR_REGISTRATION_SUCCESSFULLY_ADDED_WAITLIST'] = "Ihre Anm
 $_ARRAYLANG['TXT_CALENDAR_OCLOCK'] = "Uhr";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_SUCCESSFULLY_SAVED'] = "Veranstaltung erfolgreich gespeichert";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_CORRUPT_SAVED'] = "Fehler beim Speichern der Veranstaltung";
-$_ARRAYLANG['TXT_CALENDAR_EVENT'] = "Veranstaltung"; 
-$_ARRAYLANG['TXT_CALENDAR_EVENT_DETAILS'] = "Einzelheiten";  
-$_ARRAYLANG['TXT_CALENDAR_SAVE'] = "Speichern";   
+$_ARRAYLANG['TXT_CALENDAR_EVENT'] = "Veranstaltung";
+$_ARRAYLANG['TXT_CALENDAR_EVENT_DETAILS'] = "Einzelheiten";
+$_ARRAYLANG['TXT_CALENDAR_SAVE'] = "Speichern";
 $_ARRAYLANG['TXT_CALENDAR_EXPAND'] = "Erweitert";
-$_ARRAYLANG['TXT_CALENDAR_MINIMIZE'] = "Vereinfacht";    
-$_ARRAYLANG['TXT_CALENDAR_EVENT_PLACE'] = "Ort"; 
+$_ARRAYLANG['TXT_CALENDAR_MINIMIZE'] = "Vereinfacht";
+$_ARRAYLANG['TXT_CALENDAR_EVENT_PLACE'] = "Ort";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_STREET'] = "Strasse / Nr.";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_ZIP'] = "PLZ";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_CITY'] = "Stadt";
@@ -145,7 +145,7 @@ $_ARRAYLANG['TXT_CALENDAR_EVENT_USE_GOOGLEMAPS'] = "GoogleMaps verwenden";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_LINK'] = "Link";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_PRICE'] = "Eintrittspreis";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_FREE_PLACES'] = "Freie Plätze";
-$_ARRAYLANG['TXT_CALENDAR_EVENT_PICTURE'] = "Bild";   
+$_ARRAYLANG['TXT_CALENDAR_EVENT_PICTURE'] = "Bild";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_ATTACHMENT'] = "Anhang";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_DESCRIPTION'] = "Beschreibung";
 $_ARRAYLANG['TXT_CALENDAR_EDIT'] = "bearbeiten";
@@ -174,8 +174,6 @@ $_ARRAYLANG['TXT_CALENDAR_TIME_TYPE_NOTHING'] = "Zeit nicht anzeigen";
 $_ARRAYLANG['TXT_CALENDAR_TIME_TYPE_TIME'] = "Start- und/oder Endzeit";
 $_ARRAYLANG['TXT_CALENDAR_TIME_TYPE_FULLTIME'] = "Ganztägig";
 $_ARRAYLANG['TXT_CALENDAR_MAP'] = "Karte anzeigen";
-
-
 $_ARRAYLANG['TXT_CALENDAR_SAME_AS_CONTACT'] = "gleiche Angaben wie Kontaktadresse";
 $_ARRAYLANG['TXT_CALENDAR_DEVIATES_FROM_CONTACT'] = "weicht von der Kontaktadresse ab";
 $_ARRAYLANG['TXT_CALENDAR_PLEASE_CHECK_INPUT'] = "Bitte überprüfen sie ihre Eingabe";
@@ -192,10 +190,15 @@ $_ARRAYLANG['TXT_CALENDAR_EVENT_TYPE'] = "Veranstaltungstyp";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_TYPE_EVENT'] = "Veranstaltung";
 $_ARRAYLANG['TXT_CALENDAR_EVENT_TYPE_REDIRECT'] = "Weiterleitung";
 $_ARRAYLANG['TXT_CALENDAR_PLACE_DATA_DEFAULT'] = "Manuell erfassen";
-$_ARRAYLANG['TXT_CALENDAR_PLACE_DATA_FROM_MEDIADIR'] = "Eintrag aus dem Medienverzeichnis wählen";    
+$_ARRAYLANG['TXT_CALENDAR_PLACE_DATA_FROM_MEDIADIR'] = "Eintrag aus dem Medienverzeichnis wählen";
 $_ARRAYLANG['TXT_CALENDAR_PREV'] = "Zurück";
 $_ARRAYLANG['TXT_CALENDAR_NEXT'] = "Weiter";
 $_ARRAYLANG['TXT_CALENDAR_ACTIVE'] = "aktiv";
 $_ARRAYLANG['TXT_CALENDAR_COMMENT'] = "Beschreibung";
 $_ARRAYLANG['TXT_CALENDAR_HOST'] = "Host";
 $_ARRAYLANG['TXT_CALENDAR_NO_SERIES'] = "keine Wiederholung";
+
+// TODO: Verify the content of this entry.
+// TODO: The entry may be missing in the backend.
+// TODO: Add the entry to other languages.
+$_ARRAYLANG['TXT_CALENDAR'] = 'Veranstaltungen';

--- a/modules/Gallery/Model/Event/GalleryEventListener.class.php
+++ b/modules/Gallery/Model/Event/GalleryEventListener.class.php
@@ -27,7 +27,7 @@
 
 /**
  * EventListener for Gallery
- * 
+ *
  * @copyright   Cloudrexx AG
  * @author      Project Team SS4U <info@cloudrexx.com>
  * @package     cloudrexx
@@ -42,7 +42,7 @@ use Cx\Core\Event\Model\Entity\DefaultEventListener;
 /**
  * Class GalleryEventListener
  * EventListener for Gallery
- * 
+ *
  * @copyright   Cloudrexx AG
  * @author      Project Team SS4U <info@cloudrexx.com>
  * @package     cloudrexx
@@ -86,10 +86,15 @@ class GalleryEventListener extends DefaultEventListener {
     {
         global $_ARRAYLANG;
         \Env::get('init')->loadLanguageData('Gallery');
-        $mediaType = new MediaSource('gallery',$_ARRAYLANG['TXT_THUMBNAIL_GALLERY'],array(
-            $this->cx->getWebsiteImagesGalleryPath(),
-            $this->cx->getWebsiteImagesGalleryWebPath(),array(12,67)
-        ));
+        $mediaType = new MediaSource('gallery',
+            $_ARRAYLANG['TXT_MODULE_GALLERY_THUMBNAIL'],
+            array(
+                $this->cx->getWebsiteImagesGalleryPath(),
+                $this->cx->getWebsiteImagesGalleryWebPath(),
+            ),
+// TODO: Presumably, these are the Access IDs
+            array(12, 67)
+        );
         $mediaBrowserConfiguration->addMediaType($mediaType);
     }
 

--- a/modules/Gallery/lang/de/frontend.php
+++ b/modules/Gallery/lang/de/frontend.php
@@ -64,4 +64,8 @@ $_ARRAYLANG['TXT_GALLERY_IMAGE_DESCRIPTION'] = "Beschreibung: ";
 $_ARRAYLANG['TXT_IMAGES'] = "Bilder";
 $_ARRAYLANG['TXT_GALLERY_CATEGORY_HINT_HIERARCHY'] = "Sie sind hier:";
 $_ARRAYLANG['TXT_GALLERY_CATEGORY_HINT_FLAT'] = "Weitere Galerien:";
-?>
+
+// TODO: Verify the content of this entry.
+// TODO: The entry may be missing in the backend.
+// TODO: Add the entry to other languages.
+$_ARRAYLANG['TXT_MODULE_GALLERY_THUMBNAIL'] = 'Vorschaubild';

--- a/modules/Shop/Controller/Shop.class.php
+++ b/modules/Shop/Controller/Shop.class.php
@@ -395,7 +395,7 @@ die("Failed to get Customer for ID $customer_id");
      * @global  array   $_ARRAYLANG
      * @global  array   $themesPages
      * @global  array   $_CONFIGURATION
-     * @staticvar string    $strContent Caches created content
+     * @staticvar array $content    Caches created content
      * @param   type    $template   Replaces the default template
      *                              ($themesPages['shopnavbar']) and sets
      *                              $use_cache to false unless empty.
@@ -409,12 +409,14 @@ die("Failed to get Customer for ID $customer_id");
     static function getNavbar($template=NULL, $use_cache=true)
     {
         global $_ARRAYLANG, $themesPages;
-        static $strContent = NULL;
+        static $content = array();
 
-        if (!$use_cache) $strContent = NULL;
+        $templateHash = md5($template);
         // Note: This is valid only as long as the content is the same every
         // time this method is called!
-        if ($strContent) return $strContent;
+        if ($use_cache && array_key_exists($templateHash, $content)) {
+            return $content[$templateHash];
+        }
         $objTpl = new \Cx\Core\Html\Sigma('.');
         $objTpl->setErrorHandling(PEAR_ERROR_DIE);
         $objTpl->setTemplate(empty($template)
@@ -518,8 +520,8 @@ die("Failed to get Customer for ID $customer_id");
 //        if ($objTpl->blockExists('shopJsCart')) {
 //            $objTpl->touchBlock('shopJsCart');
 //        }
-        $strContent = $objTpl->get();
-        return $strContent;
+        $content[$templateHash] = $objTpl->get();
+        return $content[$templateHash];
     }
 
 


### PR DESCRIPTION
The EventListeners either did not load the language at all, or were using indices that did not exist.
Note that the GalleryEventListener included the Access ID array within the array of directories.
Also note that the new language entries probably need to be added to the backend and other languages, too.