### PR TITLE
Add an exclusion list to statistics, in order to exclude IP addresses from statistics.

### DIFF
--- a/core_modules/Stats/Controller/Counter.php
+++ b/core_modules/Stats/Controller/Counter.php
@@ -143,7 +143,7 @@ class Counter
                 // count spider
                 if (!$this->spiderAgent) {
                     // Check exclude list
-                    if(!$this->_skipIps()) {
+                    if($this->_skipIps($this->arrClient['ip'])) {
                         // count visitor
                         $this->_countVisitor();
                         
@@ -224,7 +224,7 @@ class Counter
      */
     function _skipIps($ip) {
         global $objDb;
-        $query = "SELECT * FROM ".DBPREFIX."stats_exclude_ip WHERE '" . $ip . "' REGEXP ip_address";
+        $query = "`SELECT * FROM ".DBPREFIX."stats_exclude_ip WHERE '" . $ip . "' REGEXP ip_address`";
         if (($objResult = $objDb->Execute($query))) {
             $count = $objResult->RecordCount();
         }

--- a/core_modules/Stats/Controller/Stats.class.php
+++ b/core_modules/Stats/Controller/Stats.class.php
@@ -1123,17 +1123,14 @@ class Stats extends StatsLibrary
     function _addIpToExclusionList($ip, $remarks) {
         global $objDatabase;
 
-        //$file = fopen("/data/www/test/log", "a+");
-//        fwrite($file,"Starting add\n");
+	// Get current user name
         $objFWUser = \FWUser::getFWUserObject();
         $userName = $objFWUser->objUser->getRealUsername();
-        
-//        $res = print_r($objFWUser, true);
-//        fwrite($file, $res . "\n");
-//        fwrite($file, $userName . "\n");
-//        fclose($file);
-        
+
+	// Trim before inserting
         $ip = trim($ip);
+
+	// Currently only fully qualified IP addresses or subnet massks.
         if(preg_match("/[0-9|\*]{1,3}\.[0-9|\*]{1,3}\.[0-9|\*]{1,3}\.[0-9|\*]{1,3}/", $ip) == 1) {
             $query = "INSERT INTO ".DBPREFIX."stats_exclude_ip(ip_address,remarks,username) VALUES('".$ip."','" . $remarks . "','" . $userName . "')";
             $objDatabase->Execute($query);

--- a/core_modules/Stats/Controller/Stats.class.php
+++ b/core_modules/Stats/Controller/Stats.class.php
@@ -1119,6 +1119,7 @@ class Stats extends StatsLibrary
      * Add a IP address to the exclusion list.
      *
      * @param ip IP address to add.
+     * @param remarks comment for the exclusion.
      */
     function _addIpToExclusionList($ip, $remarks) {
         global $objDatabase;
@@ -1132,7 +1133,7 @@ class Stats extends StatsLibrary
 
 	// Currently only fully qualified IP addresses or subnet massks.
         if(preg_match("/[0-9|\*]{1,3}\.[0-9|\*]{1,3}\.[0-9|\*]{1,3}\.[0-9|\*]{1,3}/", $ip) == 1) {
-            $query = "INSERT INTO ".DBPREFIX."stats_exclude_ip(ip_address,remarks,username) VALUES('".$ip."','" . $remarks . "','" . $userName . "')";
+            $query = "`INSERT INTO ".DBPREFIX."stats_exclude_ip(ip_address,remarks,username) VALUES('".$ip."','" . $remarks . "','" . $userName . "')`";
             $objDatabase->Execute($query);
         }
     }
@@ -1140,24 +1141,22 @@ class Stats extends StatsLibrary
     /**
      * Delete a IP address from the exclusion list.
      *
-     * @param ip IP address to delete.
+     * @param id ID of the IP address to delete.
      */
     function _delIpFromExclusionList($id) {
         global $objDatabase;
-        $query = "DELETE FROM ".DBPREFIX."stats_exclude_ip WHERE id=".$id;
+        $query = "`DELETE FROM ".DBPREFIX."stats_exclude_ip WHERE id=".$id."`";
         $objDatabase->Execute($query);
     }
 
     /**
      * Delete a IP address from the exclusion list.
      *
-     * @param ip IP address to delete.
+     * @param ids list of IP address IDs to delete.
      */
     function _delIpsFromExclusionList($ids) {
-        global $objDatabase;
         foreach ($ids as $id) {
-            $query = "DELETE FROM ".DBPREFIX."stats_exclude_ip WHERE id=".$id;
-            $objDatabase->Execute($query);
+            _delIpFromExclusionList($id);
         }
     }
 

--- a/core_modules/Stats/Controller/StatsLibrary.class.php
+++ b/core_modules/Stats/Controller/StatsLibrary.class.php
@@ -73,6 +73,7 @@ class StatsLibrary
     public $arrCountryNames = array();
     public $arrConfig = array();
     public $arrSearchTerms = array();
+    public $arrExcludeIpList = array();
     public $pagingLimit = "";
     public $pagingLimitVisitorDetails = "";
     public $spiderAgent = false;
@@ -1765,5 +1766,25 @@ class StatsLibrary
             'requests' => $arrRequests,
         );
     }
+
+    function _initExclusionList()   
+    {
+         global $objDatabase;
+             
+         $query = "SELECT id,ip_address,remarks,timestamp,username FROM ".DBPREFIX."stats_exclude_ip ORDER BY id";
+         if (($objResult = $objDatabase->Execute($query))) {
+             while (!$objResult->EOF) {
+                  $arrExcludeIp = array(
+                                        'id'         => $objResult->fields['id'],
+                                        'ip_address' => $objResult->fields['ip_address'],
+                                        'remarks'    => $objResult->fields['remarks'],
+                                        'timestamp'  => date(ASCMS_DATE_FORMAT, strtotime($objResult->fields['timestamp'])),
+                                        'username'   => $objResult->fields['username']
+                                       );
+                 array_push($this->arrExcludeIpList, $arrExcludeIp);
+                 $objResult->MoveNext();
+             }
+        }
+    } 
 }
 ?>

--- a/core_modules/Stats/View/Template/Backend/module_stats_settings.html
+++ b/core_modules/Stats/View/Template/Backend/module_stats_settings.html
@@ -1,7 +1,13 @@
 <script language="JavaScript" src="lib/javascript/set_checkboxes.js" type="text/javascript"></script>
 <script language="JavaScript" type="text/javascript">
 <!--
-
+function getRequestParameter(name){
+   if(name=(new RegExp('[?&]'+encodeURIComponent(name)+'=([^&]*)')).exec(location.search)) {
+       return decodeURIComponent(name[1]);
+   } else {
+       return null;
+   }
+}
 function toggleSettings(objCheck, objDiv) {
 	if (document.getElementById(objCheck).checked == true) {
 		document.getElementById(objDiv).style.display = "block";
@@ -9,16 +15,37 @@ function toggleSettings(objCheck, objDiv) {
 		document.getElementById(objDiv).style.display = "none";
 	}
 }
-
+function deleteIp(id) {
+        if (confirm('Wollen Sie diese IP Adresse(s) löschen?\nDiese Aktion kann nicht rückgängig gemacht werden!')) {
+                window.location.replace('index.php?cmd=stats&stat=settings&act=deleteIp&id='+id+'&{CSRF_PARAM}&tab=statsExclusionList');
+        }
+}
+function deleteIps(form)
+{
+    if (confirm('Wollen Sie diese IP Adresse(s) löschen?\nDiese Aktion kann nicht rückgängig gemacht werden!')) {
+        var f = document.getElementById(form);
+        f.action = 'index.php?cmd=stats&stat=settings&act=deleteIps&{CSRF_PARAM}&tab=statsExclusionList';
+        f.method = 'post';
+        f.submit();
+        return true;
+    }
+}
+cx.jQuery(document).ready(function() {
+    currentTab = getRequestParameter('tab');
+    if(currentTab) {
+        selectTab(currentTab); 
+    }
+});
 // -->
 </script>
 <ul id="tabmenu">
 <li><a id="settingsTab_statsSettings" class="active" href="javascript:{}" onclick="selectTab('statsSettings')" title="{TXT_SETTINGS}">{TXT_SETTINGS}</a></li>
 <li><a id="settingsTab_statsReset" href="javascript:{}" onclick="selectTab('statsReset')" title="{TXT_RESET_STATISTIC}">{TXT_RESET_STATISTIC}</a></li>
+<li><a id="settingsTab_statsExclusionList" href="javascript:{}" onclick="selectTab('statsExclusionList')" title="{TXT_EXCLUSION_LIST}">{TXT_EXCLUSION_LIST}</a></li>
 </ul>
 <!-- start statsSettings div -->
 <div id="statsSettings" class="settingsTab" style="display:block">
-<form name="stats_settings_form" action="index.php?cmd=Stats&amp;stat=settings" method="post">
+<form name="stats_settings_form" action="index.php?cmd=Stats&amp;stat=settings&amp;tab=statsSettings" method="post">
 	<table cellspacing="0" cellpadding="1" width="100%" border="0" class="adminlist">
 		<tr>
 			<th>&nbsp;{TXT_SETTINGS}</th>
@@ -91,7 +118,7 @@ function toggleSettings(objCheck, objDiv) {
 <!-- end statsSettings div -->
 <!-- start statsReset div -->
 <div id="statsReset" class="settingsTab" style="display:none">
-	<form name="stats_delete_form" action="index.php?cmd=Stats&amp;stat=settings" method="post">
+	<form name="stats_delete_form" action="index.php?cmd=Stats&amp;stat=settings&amp;tab=statsReset" method="post">
 		<table cellspacing="0" cellpadding="1" width="100%" border="0" class="adminlist">
 				<tr>
 					<th>&nbsp;{TXT_RESET_STATISTIC}</th>
@@ -179,3 +206,59 @@ function toggleSettings(objCheck, objDiv) {
 	</form>
 </div>
 <!-- end statsReset div -->
+<!-- start exclusion list div -->
+<div id="statsExclusionList" class="settingsTab" style="display:none">
+  <form name="stats_exclude_form" id="stats_exclude_form" action="index.php?cmd=stats&amp;stat=settings&amp;tab=statsExclusionList" method="post">
+    <table cellspacing="0" cellpadding="1" width="100%" border="0" class="adminlist">
+      <tr>
+	<th>&nbsp;{TXT_EXCLUSION_LIST}</th>
+      </tr>
+      <tr class="row1">
+	<td nowrap="nowrap">
+	  <label for="options_add_ip">{TXT_EXCLUSION_LIST_IP}:&nbsp;<input id="options_add_ip" name="add_ip" type="text" value="" /><label>
+	  <label for="options_remarks">{TXT_EXCLUSION_LIST_REMARKS}:&nbsp;<input id="options_remarks" name="remarks" type="text" value="" /><label>
+          <button type="submit" id="exclusion_list_add_ip">{TXT_EXCLUSION_LIST_ADD_IP}</button>
+	</td>
+      </tr>
+    </table>
+    <table cellspacing="0" cellpadding="1" width="100%" border="0" class="adminlist">
+      <tr>
+        <th colspan="7">&nbsp;{TXT_EXCLUSION_LIST_IP_TABLE}</th>
+      </tr>
+      <!-- BEGIN stats_exclusion_list -->
+      <tr class="row1">
+        <td nowrap="nowrap" width="20px"><b>#</b></td>
+        <td nowrap="nowrap" width="20%"><b>{TXT_EXCLUSION_LIST_IP}</b></td>
+        <td nowrap="nowrap" width="75%"><b>{TXT_EXCLUSION_LIST_REMARKS}</b></td>
+        <td nowrap="nowrap" width="10%"><b>{TXT_EXCLUSION_LIST_USER}</b></td>
+        <td nowrap="nowrap" width="10%"><b>{TXT_EXCLUSION_LIST_DATE}</b></td>
+        <td nowrap="nowrap" width="40px"></td>
+      </tr>
+      <!-- BEGIN stats_exclusion -->
+      <tr class="{STATS_EXCLUSION_LIST_ROW_CLASS}" style="vertical-align:top;">
+        <td nowrap="nowrap" width="20px"><input type="checkbox" name="selectedIps[]" id="selectedIps" value="{STATS_EXCLUSION_LIST_ID}"></td>
+        <td nowrap="nowrap" width="20%">{STATS_EXCLUSION_LIST_IP}</td>
+        <td nowrap="nowrap" width="75%">{STATS_EXCLUSION_LIST_REMARKS}</td>
+        <td nowrap="nowrap" width="10%">{STATS_EXCLUSION_LIST_USER}</td>
+        <td nowrap="nowrap" width="10%">{STATS_EXCLUSION_LIST_DATE}</td>
+        <td nowrap="nowrap" width="40px">
+          <div align="right">
+            <a href="javascript:deleteIp({STATS_EXCLUSION_LIST_ID})"><img src="../core/Core/View/Media/icons/delete.gif" border="0" alt="Löschen"></a>
+          </div>
+        </td>
+      </tr>
+      <!-- END stats_exclusion -->
+      <!-- END stats_exclusion_list -->
+      <!-- BEGIN stats_exclusion_list_nodata -->
+      <tr class="row1">
+        <td nowrap="nowrap" width="100%" colspan="7">{TXT_NO_DATA_AVAILABLE}</td>
+      </tr>
+      <!-- END stats_exclusion_list_nodata -->
+    </table>
+    <img src="../core/Core/View/Media/icons/arrow.gif" border="0" width="38" height="22" alt="{TXT_MARKED}:" />
+    <a href="#" onclick="changeCheckboxes('stats_exclude_form','selectedIps[]',true); return false;">{TXT_SELECT_ALL}</a>&nbsp;/&nbsp;
+    <a href="#" onclick="changeCheckboxes('stats_exclude_form','selectedIps[]',false); return false;">{TXT_REMOVE_SELECTION}</a>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+    <input type="button" name="delete" value="{TXT_EXCLUSION_LIST_DELETE_MARKED}" onclick="deleteIps('stats_exclude_form');" />&nbsp;&nbsp;
+  </form>
+</div>
+<!-- start exclusion list div -->

--- a/core_modules/Stats/lang/de/backend.php
+++ b/core_modules/Stats/lang/de/backend.php
@@ -169,4 +169,13 @@ $_ARRAYLANG['TXT_PAGING_LIMIT'] = "Anzeigelimit für Statistikauswertung";
 $_ARRAYLANG['TXT_PAGING_LIMIT_VISITOR_DETAILS'] = "Anzeigelimit für Besucherdetails";
 $_ARRAYLANG['TXT_IMAGE_EDIT_SHOW'] = "Anzeigen";
 $_ARRAYLANG['TXT_STATS_COUNT_VISIOTR_NUMBER'] = "Nummer des aktuellen Besuchers berechnen. Diese Option muss aktiviert sein, falls Sie den Platzhalter [[VISITOR_NUMBER]] im Frontend verwenden wollen.";
+$_ARRAYLANG['TXT_EXCLUSION_LIST'] = "IP Adressen ignorieren";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP_TABLE'] = "Ignorierte IP Adressen";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ID'] = "ID";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP'] = "IP Adresse";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_REMARKS'] = "Bemerkungen";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DATE'] = "Datum";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_USER'] = "Benutzer";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ADD_IP'] = "IP Adresse hinzufügen";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DELETE_MARKED'] = "Markierte löschen";
 ?>

--- a/core_modules/Stats/lang/dk/backend.php
+++ b/core_modules/Stats/lang/dk/backend.php
@@ -168,4 +168,13 @@ $_ARRAYLANG['TXT_PAGING_LIMIT'] = "Anzeigelimit für Statistikauswertung";
 $_ARRAYLANG['TXT_PAGING_LIMIT_VISITOR_DETAILS'] = "Anzeigelimit für Besucherdetails";
 $_ARRAYLANG['TXT_IMAGE_EDIT_SHOW'] = "Show";
 $_ARRAYLANG['TXT_STATS_COUNT_VISIOTR_NUMBER'] = "Nummer des aktuellen Besuchers berechnen. Diese Option muss aktiviert sein, falls Sie den Platzhalter [[VISITOR_NUMBER]] im Frontend verwenden wollen.";
+$_ARRAYLANG['TXT_EXCLUSION_LIST'] = "Skip IP-adresser";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP_TABLE'] = "Skip IP-adresser";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ID'] = "ID";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP'] = "IP-adresser";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_REMARKS'] = "Bemærkninger";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DATE'] = "Dato";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_USER'] = "Bruger";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ADD_IP'] = "Tilføje ip-adresse";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DELETE_MARKED'] = "Slet markerede";
 ?>

--- a/core_modules/Stats/lang/en/backend.php
+++ b/core_modules/Stats/lang/en/backend.php
@@ -169,4 +169,13 @@ $_ARRAYLANG['TXT_PAGING_LIMIT'] = "Statistical Records Limit";
 $_ARRAYLANG['TXT_PAGING_LIMIT_VISITOR_DETAILS'] = "Visitor Details Limit";
 $_ARRAYLANG['TXT_IMAGE_EDIT_SHOW'] = "Show";
 $_ARRAYLANG['TXT_STATS_COUNT_VISIOTR_NUMBER'] = "Compute the number of the current visitor. This option must be enabled if you intend to use the placeholder [[VISITOR_NUMBER]] in the frontend.";
+$_ARRAYLANG['TXT_EXCLUSION_LIST'] = "Skip IP addresses";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP_TABLE'] = "Skip IP address";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ID'] = "ID";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP'] = "IP address";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_REMARKS'] = "Remarks";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DATE'] = "Date";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_USER'] = "User";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ADD_IP'] = "Add IP address";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DELETE_MARKED'] = "Delete marked";
 ?>

--- a/core_modules/Stats/lang/it/backend.php
+++ b/core_modules/Stats/lang/it/backend.php
@@ -168,4 +168,13 @@ $_ARRAYLANG['TXT_PAGING_LIMIT'] = "Anzeigelimit für Statistikauswertung";
 $_ARRAYLANG['TXT_PAGING_LIMIT_VISITOR_DETAILS'] = "Anzeigelimit für Besucherdetails";
 $_ARRAYLANG['TXT_IMAGE_EDIT_SHOW'] = "Show";
 $_ARRAYLANG['TXT_STATS_COUNT_VISIOTR_NUMBER'] = "Nummer des aktuellen Besuchers berechnen. Diese Option muss aktiviert sein, falls Sie den Platzhalter [[VISITOR_NUMBER]] im Frontend verwenden wollen.";
+$_ARRAYLANG['TXT_EXCLUSION_LIST'] = "Skip indirizzi IP";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP_TABLE'] = "Skip indirizzi IP";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ID'] = "ID";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP'] = "Indirizzi IP";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_REMARKS'] = "Osservazioni";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DATE'] = "Date";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_USER'] = "Utente";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ADD_IP'] = "Aggiungere l'indirizzo IP";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DELETE_MARKED'] = "Elimina segnati";
 ?>

--- a/core_modules/Stats/lang/ru/backend.php
+++ b/core_modules/Stats/lang/ru/backend.php
@@ -168,4 +168,13 @@ $_ARRAYLANG['TXT_PAGING_LIMIT'] = "Anzeigelimit für Statistikauswertung";
 $_ARRAYLANG['TXT_PAGING_LIMIT_VISITOR_DETAILS'] = "Anzeigelimit für Besucherdetails";
 $_ARRAYLANG['TXT_IMAGE_EDIT_SHOW'] = "Anzeigen";
 $_ARRAYLANG['TXT_STATS_COUNT_VISIOTR_NUMBER'] = "Nummer des aktuellen Besuchers berechnen. Diese Option muss aktiviert sein, falls Sie den Platzhalter [[VISITOR_NUMBER]] im Frontend verwenden wollen.";
+$_ARRAYLANG['TXT_EXCLUSION_LIST'] = "Пропустить IP-адреса";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP_TABLE'] = "Пропустить IP-адрес";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ID'] = "Я БЫ";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_IP'] = "Aйпи адрес";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_REMARKS'] = "замечания";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_USER'] = "пользователь";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DATE'] = "Дата";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_ADD_IP'] = "Добавить IP-адрес";
+$_ARRAYLANG['TXT_EXCLUSION_LIST_DELETE_MARKED'] = "Удалить отмеченные";
 ?>

--- a/installer/data/contrexx_dump_structure.sql
+++ b/installer/data/contrexx_dump_structure.sql
@@ -3732,3 +3732,11 @@ CREATE TABLE `contrexx_voting_system` (
   `additional_comment` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`)
 ) ENGINE=MyISAM ;
+CREATE TABLE `contrexx_stats_exclude_ip` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `ip_address` varchar(60) NOT NULL DEFAULT '',
+  `remarks` varchar(255) DEFAULT '',
+  `timestamp` timestamp NOT NULL,
+  `username` varchar(255) DEFAULT '',
+  PRIMARY KEY (`id`)
+) ENGINE=MyISAM ;

--- a/lib/javascript/cx_tabs.js
+++ b/lib/javascript/cx_tabs.js
@@ -7,8 +7,10 @@
 	<div id="DIVNAME2" class="CLASSNAME"></div>
 */
 
+var currentTab;
 function selectTab(tabName)
 {
+        currentTab = tabName;
 	if(document.getElementById(tabName).style.display != "block")
 	{
 		document.getElementById(tabName).style.display = "block";


### PR DESCRIPTION
This is a small extention to the Stats package, which allows to define an exclusion list containing IP addresses ot network subnet masks from entering the statistics. The extension adds a new tabs to the statistics settings admin page, which allows to add/delete IP addresses/subnet masks from the exclusion list. All request IP addresses matching the defined entries will not enter in the statistics. 

A new table has been added: '<prefix>_stats_exclude_ip' containing id,ip_address,remarks,username,timestamp.

A small extension is also added to the tabs configuration, so that after a commit (add/delete) the current tab is reselected.

Screenshot:
<img width="953" alt="exclude_list" src="https://cloud.githubusercontent.com/assets/18611563/17594807/db824c64-5fea-11e6-86bd-746af8eeb529.png">
