### PR TITLE
Fix condition to fire only when appropriate

### DIFF
--- a/core/Config/Model/Event/YamlSettingEventListener.class.php
+++ b/core/Config/Model/Event/YamlSettingEventListener.class.php
@@ -108,7 +108,6 @@ class YamlSettingEventListener implements \Cx\Core\Event\Model\Entity\EventListe
                     $value = \Cx\Core\Config\Controller\Config::checkAccessibility($protocol) ? $value : 'off';
                     $objSetting->setValue($value);
                     break;
-                
                 case 'cacheReverseProxy':
                 case 'cacheProxyCacheConfig':
                     if ($value != $_CONFIG[$objSetting->getName()]) {
@@ -116,7 +115,6 @@ class YamlSettingEventListener implements \Cx\Core\Event\Model\Entity\EventListe
                         \Cx\Core\Core\Controller\Cx::instanciate()->getComponent('Cache')->clearReverseProxyCache('*');
                     }
                     break;
-                
                 case 'cacheSsiOutput':
                 case 'cacheSsiType':
                 case 'cacheSsiProcessorConfig':
@@ -139,13 +137,14 @@ class YamlSettingEventListener implements \Cx\Core\Event\Model\Entity\EventListe
         }
     }
 
-    public function onEvent($eventName, array $eventArgs) {
-        \DBG::msg(__METHOD__);
-        if ($eventName == 'postFlush') {
-            if (isset($eventArgs[1]) && !preg_match('#\b(Config.yml)\b#', $eventArgs[1])) {
-                return false;
-            }
+    public function onEvent($eventName, array $eventArgs)
+    {
+// Fixed condition
+        if ($eventName === 'postFlush'
+            && isset($eventArgs[1])
+            && preg_match('/\\bConfig\\.yml\\b/', $eventArgs[1])) {
+                $this->$eventName(current($eventArgs));
         }
-        $this->$eventName(current($eventArgs));
     }
+
 }


### PR DESCRIPTION
Without this fix, each call of onEvent() seems to fire, regardless of the parameters provided.
The change improves performance notably