### PR TITLE
Fix media type paths

### DIFF
--- a/core/MediaSource/Model/Entity/MediaSourceManager.class.php
+++ b/core/MediaSource/Model/Entity/MediaSourceManager.class.php
@@ -225,7 +225,9 @@ class MediaSourceManager extends EntityBase
      * @return array
      */
     public function getMediaTypePathsbyNameAndOffset($name, $offset) {
-        return $this->mediaTypePaths[$name][$offset];
+        return (array_key_exists($name, $this->mediaTypePaths)
+            && array_key_exists($offset, $this->mediaTypePaths[$name])
+            ? $this->mediaTypePaths[$name][$offset] : null);
     }
 
     public function getAllMediaTypePaths() {


### PR DESCRIPTION
"C:" no longer causes a PHP warning, resulting in an invalid path