### PR TITLE
Catch Null Keys in RecursiveArrayAccess

### DIFF
--- a/core/Model/RecursiveArrayAccess.class.php
+++ b/core/Model/RecursiveArrayAccess.class.php
@@ -185,7 +185,7 @@ class RecursiveArrayAccess implements \ArrayAccess, \Countable, \Iterator {
      * @return boolean true on success or false on failure.
      */
     public function offsetExists($offset) {
-        return isset($this->data[$offset]);
+        return !is_null($offset) && isset($this->data[$offset]);
     }
 
     /**


### PR DESCRIPTION
Catch null keys in the RecursiveArrayAccess iterator.
Without this, the iterator will loop forever if a null key occurs.