### PR TITLE
Fix Widget in Minimal Mode

### DIFF
--- a/core/ContentManager/Controller/ComponentController.class.php
+++ b/core/ContentManager/Controller/ComponentController.class.php
@@ -82,6 +82,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     public function postInit(\Cx\Core\Core\Controller\Cx $cx)
     {
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         foreach (
             array(
                 'TITLE',

--- a/core/Core/Controller/ComponentController.class.php
+++ b/core/Core/Controller/ComponentController.class.php
@@ -53,6 +53,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     public function postInit(\Cx\Core\Core\Controller\Cx $cx)
     {
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         $widgetController->registerWidget(
             new \Cx\Core_Modules\Widget\Model\Entity\FinalStringWidget(
                 $this,
@@ -248,7 +252,7 @@ Available commands:
             // else return 'customized';
         return 'normal';
     }
-    
+
     /**
      * Executes a command (in CLI command mode) asynchronously
      * @param string $command Command mode command name to execute

--- a/core/LanguageManager/Controller/ComponentController.class.php
+++ b/core/LanguageManager/Controller/ComponentController.class.php
@@ -280,7 +280,7 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
         }
         $this->parseLocaleList($template);
     }
-    
+
     /**
      * Parses locale list in a template file
      * @todo Does language list only for now. Update as soon as locales are available
@@ -350,6 +350,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     public function postInit(\Cx\Core\Core\Controller\Cx $cx)
     {
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         $langManager      = new LanguageManager();
         $widgetNames      = array(
             'CHARSET',

--- a/core/View/Controller/ComponentController.class.php
+++ b/core/View/Controller/ComponentController.class.php
@@ -79,6 +79,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
      */
     public function postInit(\Cx\Core\Core\Controller\Cx $cx) {
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         $widgetNames = array(
             'STANDARD_URL',
             'MOBILE_URL',

--- a/core_modules/Access/Controller/ComponentController.class.php
+++ b/core_modules/Access/Controller/ComponentController.class.php
@@ -219,6 +219,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     public function postInit(\Cx\Core\Core\Controller\Cx $cx)
     {
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         foreach (
             array(
                 'logged_in',

--- a/core_modules/Contact/Controller/ComponentController.class.php
+++ b/core_modules/Contact/Controller/ComponentController.class.php
@@ -73,6 +73,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
             'coreAdminName' => 'Name',
         );
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         foreach ($globalPlaceholders as $configIndex=>$placeholder) {
             if (is_int($configIndex)) {
                 $configIndex = 'contact' . $placeholder;

--- a/modules/Calendar/Controller/ComponentController.class.php
+++ b/modules/Calendar/Controller/ComponentController.class.php
@@ -120,6 +120,10 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     {
         // Get Calendar Events
         $widgetController = $this->getComponent('Widget');
+        if (!$widgetController) {
+            // Not available in minimal mode?
+            return;
+        }
         $calendarLib      = new CalendarLibrary('');
         foreach ($calendarLib->getHeadlinePlaceholders() as $widgetName) {
             $widget = new \Cx\Core_Modules\Widget\Model\Entity\EsiWidget(


### PR DESCRIPTION
At least when running in minimal mode (e.g., when using the workbench batch), initialization fails in multiple places, for the widget component is not present.