### PR TITLE
fix(languagemanager): correct comparison of placeholder with locale

### DIFF
--- a/core/LanguageManager/Controller/EsiWidgetController.class.php
+++ b/core/LanguageManager/Controller/EsiWidgetController.class.php
@@ -80,12 +80,12 @@ class EsiWidgetController extends \Cx\Core_Modules\Widget\Controller\EsiWidgetCo
             preg_match(
                 '/^LANG_SELECTED_([A-Z]{1,2}(?:_[A-Z]{2,4})?)$/',
                 $name,
-                $matches
+                $matches // E.g., "FR_CH"
             )
         ) {
             $selected = '';
-            $langCode = $params['locale']->getShortForm();
-            if ($matches[1] === strtoupper($langCode)) {
+            $langCode = $params['locale']->getShortForm(); // E.g., "fr-CH"
+            if (str_replace('_', '-', $matches[1]) === strtoupper($langCode)) {
                 $selected = 'selected';
             }
             $template->setVariable($name, $selected);


### PR DESCRIPTION
The LanguageManager must replace the underscore from the placeholder with a dash in order to match the locale.
Added comments with samples for illustration and documentation.