### PR TITLE
fix(pdf): apply page box CSS from template

### DIFF
--- a/core_modules/Pdf/Model/Entity/PdfDocument.class.php
+++ b/core_modules/Pdf/Model/Entity/PdfDocument.class.php
@@ -117,7 +117,6 @@ class PdfDocument extends \mPDF
             $this->SetAuthor($_CONFIG['coreCmsName']);
         }
         $this->SetDisplayPreferences('HideWindowUI');
-        $this->AddPage();
         $this->WriteHTML($this->content);
         if (empty($this->filePath)) {
             $this->filePath = \Cx\Lib\FileSystem\FileSystem::replaceCharacters(


### PR DESCRIPTION
The call to addPage() is not only unnecessary, but breaks any custom page, header, and footer margins from being applied.
Required for PARKWebShop.