### PR TITLE
feat(pdf): take website author as pdf author

### DIFF
--- a/core_modules/Pdf/Model/Entity/PdfDocument.class.php
+++ b/core_modules/Pdf/Model/Entity/PdfDocument.class.php
@@ -114,7 +114,11 @@ class PdfDocument extends \mPDF
             ->getCodeBaseCoreModulePath();
         $this->noImageFile = $coreModulePath . '/Pdf/View/Media/no_picture.gif';
         if (empty($this->author)) {
-            $this->SetAuthor($_CONFIG['coreCmsName']);
+            if (isset($_CONFIG['coreAdminName'])) {
+                $this->SetAuthor($_CONFIG['coreAdminName']);
+            } else {
+                $this->SetAuthor($_CONFIG['coreCmsName']);
+            }
         }
         $this->SetDisplayPreferences('HideWindowUI');
         $this->AddPage();


### PR DESCRIPTION
Instead of using the cms name ("Cloudrexx") as pdf author, we should use the name of the website admin.