### PR TITLE
Seil 184 several maps in mediadir forms

### DIFF
--- a/lib/googleServices/googleMap.class.php
+++ b/lib/googleServices/googleMap.class.php
@@ -46,6 +46,11 @@ class googleMap
 {
     private $apiKey;
 
+    /**
+     * @var bool if the google map js is already loaded
+     */
+    protected static $jsLoaded = false;
+
     private $mapModus = 'overview';
     private $mapDimensions;
     private $mapZoom = 1;
@@ -149,7 +154,7 @@ class googleMap
 
 
 
-    function addMapMarker($id, $lon, $lat, $info, $hideInfo=true, $click=null, $mouseover=null, $mouseout=null, $icon=null)
+    function addMapMarker($id, $lon, $lat, $info = '', $hideInfo=true, $click=null, $mouseover=null, $mouseout=null, $icon=null)
     {
         $this->mapMarkers[$id]['lon'] = $lon;
         $this->mapMarkers[$id]['lat'] = $lat;
@@ -253,10 +258,160 @@ EOF;
         return $layer;
     }
 
-
-
+    /**
+     * Get a script tag to instantiate a Google Map with search functions. To
+     * use the search fields, define a \ContrexxJavascript variable with an array
+     * and the search fields IDs. For example:
+     * array(
+     *     'long' => 'long-search-field-id',
+     *     'lat' => 'lat-search-field-id',
+     *     'zoom' => 'zoom-search-field-id',
+     *     'street' => 'street-search-field-id',
+     *     'zip' => 'zip-search-field-id,
+     *     'city' => 'city-search-field-id
+     * );
+     *
+     * @return string
+     */
     private function getSearchMap()
     {
-        return "not yet implemented";
+        \JS::activate('cx');
+
+        $layer = '<div id="'.$this->mapId.'" '.$this->mapClass.' '.$this->mapDimensions.'></div>';
+
+        $this->loadMapMarkers();
+        $map = 'map_'.$this->mapIndex;
+        $jsScriptTag = $this->getScriptTagToLoadGoogleMaps();
+
+        $layer .= <<<EOF
+$jsScriptTag
+<script>
+//<![CDATA[
+var $map;
+
+cx.ready(function() {
+    const elZoom = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').zoom
+    );
+    const elLon = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').long
+    );
+    const elLat = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').lat
+    );
+
+    var $map = new google.maps.Map(document.getElementById("$this->mapId"));
+    cx.variables.set('map_{$this->mapIndex}', $map, '$this->mapId');
+    $this->mapCenter
+
+    $map.setCenter(center);
+    
+    $map.setZoom($this->mapZoom);
+
+    $map.setMapTypeId(google.maps.MapTypeId.$this->mapType);
+
+    var mapMarkers = cx.variables.get('map_{$this->mapIndex}_markers', '$this->mapId');
+    for (var key in mapMarkers) {
+        if (!mapMarkers.hasOwnProperty(key)) {
+            continue;
+        }
+
+        var mapMarker = mapMarkers[key];
+        mapMarker.marker = new google.maps.Marker({
+            position: new google.maps.LatLng(mapMarker.lat, mapMarker.lon),
+            map: map_$this->mapIndex,
+            draggable:true,
+            animation: google.maps.Animation.DROP
+        });
+        
+        google.maps.event.addListener(mapMarker.marker, 'dragend', function(event) {
+            if (event.latLng.lat()) {
+               elLat.value = event.latLng.lat();
+            }
+            if(event.latLng.lng()){
+               elLon.value = event.latLng.lng();
+            }
+            $map.setCenter(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
+        });
+        
+        // Use the same ID for the search btn as for the marker
+        document.getElementById(key).addEventListener('click', function() {
+            const elStreet = document.getElementById(
+                cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').street
+            );
+            const elZip = document.getElementById(
+                cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').zip
+            );
+            const elCity = document.getElementById(
+                cx.variables.get('map_search_field_ids', 'map_$this->mapIndex').city
+            );
+            var address =  elStreet.value + " " + elZip.value + " " + elCity.value + " CH";
+        
+            var geocoder = new google.maps.Geocoder();
+            
+            if (geocoder) {
+                geocoder.geocode( { 'address': address}, function(results, status) {
+                    if (status == google.maps.GeocoderStatus.OK) {
+                        setPosition(results[0].geometry.location, $map, '$this->mapIndex', mapMarker.marker);
+                        $map.setCenter(results[0].geometry.location);
+                    }
+                });
+            }
+        });
+        
+        google.maps.event.addListener($map, "click", function(event) {
+            setPosition(event.latLng, $map, '$this->mapIndex', mapMarker.marker);
+        });
+
+        // in selection mode, we want only one marker.
+        // therefore, do not process any more markers
+        break;
+    }
+
+    google.maps.event.addListener($map, "idle", function() {
+        elZoom.value = $map.getZoom();
+    });
+    
+});
+
+function setPosition(position, map, mapIndex, marker) {
+    const elZoom = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_' + mapIndex).zoom
+    );
+    const elLon = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_' + mapIndex).long
+    );
+    const elLat = document.getElementById(
+        cx.variables.get('map_search_field_ids', 'map_' + mapIndex).lat
+    );
+    if (!marker) {
+        marker = new google.maps.Marker({
+            map: map
+        });
+    }
+    marker.set('position', position);
+    elZoom.value = map.getZoom();
+    elLon.value = position.lng();
+    elLat.value = position.lat();
+}
+//]]>
+</script>
+EOF;
+        return $layer;
+    }
+
+    /**
+     * Get the script tag to load the google map js or an empty string. If the
+     * script is already loaded, return an empty string
+     *
+     * @return string script tag or empty string
+     */
+    protected function getScriptTagToLoadGoogleMaps() {
+        if (static::$jsLoaded) {
+            return '<script src="https://maps.googleapis.com/maps/api/js?key='
+                .$this->apiKey.'&sensor=false&v=3"></script>';
+        }
+        static::$jsLoaded = true;
+        return '';
     }
 }

--- a/lib/googleServices/googleMap.class.php
+++ b/lib/googleServices/googleMap.class.php
@@ -46,11 +46,6 @@ class googleMap
 {
     private $apiKey;
 
-    /**
-     * @var bool if the google map js is already loaded
-     */
-    protected static $jsLoaded = false;
-
     private $mapModus = 'overview';
     private $mapDimensions;
     private $mapZoom = 1;
@@ -281,10 +276,9 @@ EOF;
 
         $this->loadMapMarkers();
         $map = 'map_'.$this->mapIndex;
-        $jsScriptTag = $this->getScriptTagToLoadGoogleMaps();
 
         $layer .= <<<EOF
-$jsScriptTag
+<script src="https://maps.googleapis.com/maps/api/js?key=$this->apiKey&sensor=false&v=3"></script>
 <script>
 //<![CDATA[
 var $map;
@@ -400,18 +394,4 @@ EOF;
         return $layer;
     }
 
-    /**
-     * Get the script tag to load the google map js or an empty string. If the
-     * script is already loaded, return an empty string
-     *
-     * @return string script tag or empty string
-     */
-    protected function getScriptTagToLoadGoogleMaps() {
-        if (static::$jsLoaded) {
-            return '<script src="https://maps.googleapis.com/maps/api/js?key='
-                .$this->apiKey.'&sensor=false&v=3"></script>';
-        }
-        static::$jsLoaded = true;
-        return '';
-    }
 }

--- a/modules/MediaDir/Model/Entity/MediaDirectoryInputfieldGoogleMap.class.php
+++ b/modules/MediaDir/Model/Entity/MediaDirectoryInputfieldGoogleMap.class.php
@@ -115,27 +115,56 @@ class MediaDirectoryInputfieldGoogleMap extends \Cx\Modules\MediaDir\Controller\
                     $strValueZoom = empty($arrValues[2]) ? 0 : $arrValues[2];
                 }
 
-                $strMapId       = $this->moduleNameLC.'Inputfield_'.$intId.'_map';
-                $strLonId       = $this->moduleNameLC.'Inputfield_'.$intId.'_lon';
-                $strLatId       = $this->moduleNameLC.'Inputfield_'.$intId.'_lat';
-                $strZoomId      = $this->moduleNameLC.'Inputfield_'.$intId.'_zoom';
-                $strStreetId    = $this->moduleNameLC.'Inputfield_'.$intId.'_street';
-                $strZipId       = $this->moduleNameLC.'Inputfield_'.$intId.'_zip';
-                $strCityId      = $this->moduleNameLC.'Inputfield_'.$intId.'_city';
-                $strKey         = $_CONFIG['googleMapsAPIKey'];
+                $strMapId       = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_map';
+                $mapIndex       = $intEntryId.'_'.$intId;
+
+                $strLonId       = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_lon';
+                $strLatId       = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_lat';
+                $strZoomId      = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_zoom';
+                $strStreetId    = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_street';
+                $strZipId       = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_zip';
+                $strCityId      = $this->moduleNameLC.'Inputfield_'.$intEntryId.'_'.$intId.'_city';
+
+            $searchFieldIds = array(
+                    'long' => $strLonId,
+                    'lat' => $strLatId,
+                    'zoom' => $strZoomId,
+                    'street' => $strStreetId,
+                    'zip' => $strZipId,
+                    'city' => $strCityId
+                );
+
+                \ContrexxJavascript::getInstance()->setVariable(
+                    'map_search_field_ids',
+                    $searchFieldIds,
+                    'map_' . $mapIndex
+                );
+
+                $objGoogleMap = new \googleMap();
+                $objGoogleMap->setMapModus('search');
+                $objGoogleMap->setMapId($strMapId);
+                $objGoogleMap->setMapIndex($mapIndex);
+                $objGoogleMap->setMapZoom($strValueZoom);
+                $objGoogleMap->setMapCenter($strValueLon, $strValueLat);
+                $objGoogleMap->addMapMarker(
+                    $this->moduleNameLC.'Inputfield_'.$intEntryId .'_'.$intId.'_search',
+                    $strValueLon,
+                    $strValueLat
+                );
 
                 if($objInit->mode == 'backend') {
+                    $objGoogleMap->setMapStyleClass('mediadir-map');
                     $strInputfield  = '<table cellpadding="0" cellspacing="0" border="0" class="'.$this->moduleNameLC.'TableGoogleMap">';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_STREET'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][street]" id="'.$strStreetId.'" value="'.$strValueStreet.'" onfocus="this.select();" /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_CITY'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][place]" id="'.$strZipId.'"  value="'.$strValueZip.'" onfocus="this.select();" /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_ZIP'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][zip]" id="'.$strCityId.'" value="'.$strValueCity.'" onfocus="this.select();" /></td></tr>';
-                    $strInputfield .= '<tr><td style="border: 0px;"><br /></td><td style="border: 0px;"><input type="button" onclick="searchAddress();" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][search]" id="'.$this->moduleNameLC.'Inputfield_'.$intId.'_search" value="'.$_CORELANG['TXT_SEARCH'].'" /></td></tr>';
+                    $strInputfield .= '<tr><td style="border: 0px;"><br /></td><td style="border: 0px;"><input type="button" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][search]" id="'.$this->moduleNameLC.'Inputfield_'.$intEntryId .'_'.$intId.'_search" value="'.$_CORELANG['TXT_SEARCH'].'" /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;" coldpan="2"><br /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_LON'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][lon]" id="'.$strLonId.'"  value="'.$strValueLon.'" onfocus="this.select();" /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_LAT'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][lat]" id="'.$strLatId.'" value="'.$strValueLat.'" onfocus="this.select();" /></td></tr>';
                     $strInputfield .= '<tr><td style="border: 0px;">'.$_ARRAYLANG['TXT_MEDIADIR_GOOGLE_MAP_ZOOM'].':&nbsp;&nbsp;</td><td style="border: 0px; padding-bottom: 2px;"><input type="text" name="'.$this->moduleNameLC.'Inputfield['.$intId.'][zoom]" id="'.$strZoomId.'" value="'.$strValueZoom.'" onfocus="this.select();" /></td></tr>';
                     $strInputfield .= '</table><br />';
-                    $strInputfield .= '<div id="'.$strMapId.'" style="border: solid 1px #0A50A1; width: 418px; height: 300px;"></div>';
+                    $strInputfield .= $objGoogleMap->getMap();
 
                 } else {
                     $strInputfield  = '<div class="'.$this->moduleNameLC.'GoogleMap" style="float: left; height: auto ! important;">';
@@ -153,91 +182,10 @@ class MediaDirectoryInputfieldGoogleMap extends \Cx\Modules\MediaDir\Controller\
                     $strInputfield .= '</fieldset>';
                     $strInputfield .= '</div>';
                     $strInputfield .= '<div class="'.$this->moduleNameLC.'GoogleMap" style="float: left; height: auto ! important;">';
-                    $strInputfield .= '<div id="'.$strMapId.'" class="map"></div>';
+                    $strInputfield .= $objGoogleMap->getMap();;
                     $strInputfield .= '</div>';
                 }
 
-                $strInputfield .= <<<EOF
-<script src="https://maps.googleapis.com/maps/api/js?key=$strKey&sensor=false&v=3"></script>
-<script>
-//<![CDATA[
-var elZoom, elLon, elLat, elStreet, elZip, elCity;
-var map, marker, geocoder, old_marker = null;
-
-function initialize() {
-    elZoom = document.getElementById("$strZoomId");
-    elLon = document.getElementById("$strLonId");
-    elLat = document.getElementById("$strLatId");
-
-    elStreet = document.getElementById("$strStreetId");
-    elZip = document.getElementById("$strZipId");
-    elCity = document.getElementById("$strCityId");
-
-    map = new google.maps.Map(document.getElementById("$strMapId"));
-
-    map.setCenter(new google.maps.LatLng($strValueLat, $strValueLon));
-    map.setZoom($strValueZoom);
-    map.setMapTypeId(google.maps.MapTypeId.ROADMAP);
-
-    if($strValueLon != 0 && $strValueLon != 0) {
-        marker = new google.maps.Marker({
-            map: map,
-            draggable:true,
-            animation: google.maps.Animation.DROP
-        });
-        setPosition(new google.maps.LatLng($strValueLat, $strValueLon));
-
-        google.maps.event.addListener(marker, 'dragend', function(event){
-            if(event.latLng.lat()){
-               elLat.value = event.latLng.lat();
-            }
-            if(event.latLng.lng()){
-               elLon.value = event.latLng.lng();
-            }
-            map.setCenter(new google.maps.LatLng(event.latLng.lat(), event.latLng.lng()));
-        });
-    }
-
-    geocoder = new google.maps.Geocoder();
-
-    google.maps.event.addListener(map, "click", function(event) {
-        setPosition(event.latLng);
-    });
-
-    google.maps.event.addListener(map, "idle", function() {
-        elZoom.value = map.getZoom();
-    });
-}
-
-function searchAddress() {
-    var address =  elStreet.value + " " + elZip.value + " " + elCity.value;
-
-    if (geocoder) {
-        geocoder.geocode( { 'address': address}, function(results, status) {
-            if (status == google.maps.GeocoderStatus.OK) {
-                setPosition(results[0].geometry.location);
-                map.setCenter(results[0].geometry.location);
-            }
-        });
-    }
-}
-
-function setPosition(position) {
-    if (!marker) {
-        marker = new google.maps.Marker({
-            map: map
-        });
-    }
-    marker.setPosition(position);
-    elZoom.value = map.getZoom();
-    elLon.value = position.lng();
-    elLat.value = position.lat();
-}
-
-google.maps.event.addDomListener(window, 'load', initialize);
-//]]>
-</script>
-EOF;
                 return $strInputfield;
 
                 break;

--- a/modules/MediaDir/View/Template/Backend/module_mediadir_modify_entry.html
+++ b/modules/MediaDir/View/Template/Backend/module_mediadir_modify_entry.html
@@ -119,8 +119,12 @@ cx.jQuery(document).ready(function() {
         width: 300px;
         padding-left: 3px !important;
     }
+    .mediadir-map {
+        border: solid 1px #0A50A1;
+        width: 418px;
+        height: 300px;
+    }
 </style>
-
 <form name="entryModfyForm" action="index.php?cmd={MODULE_NAME}&act=modify_entry" onsubmit="{MEDIADIR_FORM_ONSUBMIT}" method="post" enctype="multipart/form-data">
 <input name="entryId" type="hidden" value="{MEDIADIR_ENTRY_ID}" />
 <input name="formId" type="hidden" value="{MEDIADIR_FORM_ID}" />


### PR DESCRIPTION
In the MediaDir component, several fields are defined as `Google Map`. If an entry is edited, the maps do not react, only the last map works correctly. This is because all Google Maps have the same ID. 

To solve this problem, the `getSearchMap` method was implemented in the class `googleMap`. The JavaScript code, which was already used in MediaDir, was adopted and modified. 

The script tag, which integrates the Google Map JS Library, is inserted several times. This leads to JavaScript errors. The static variable `$jsLoaded` was added, which checks if the script tag has already been inserted.