### PR TITLE
Downloads show breadcrumb of category

### DIFF
--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2401,7 +2401,8 @@ class DownloadsManager extends DownloadsLibrary
 
 
         if ($objCategory->getId()) {
-            $parentNames = $this->getParentCategoryNamesByChild($objCategory);
+            $parentNames = array();
+            $this->getParentCategoryNamesByChild($objCategory, $parentNames);
 
             $categories = array(
                 'root' => array(),
@@ -2506,15 +2507,14 @@ class DownloadsManager extends DownloadsLibrary
      *
      * @param \Cx\Modules\Downloads\Controller\Category $child child category
      * @param array $names previous category names for recursion
-     * @return array array with all names
      */
     protected function getParentCategoryNamesByChild(
         \Cx\Modules\Downloads\Controller\Category $child,
-        array $names = array()
-    ) : array {
+        array &$names
+    ) {
         if (empty($child->getParentId())) {
             $names[] = $child->getName();
-            return $names;
+            return;
         }
 
         $parent = \Cx\Modules\Downloads\Controller\Category::getCategory(
@@ -2522,11 +2522,11 @@ class DownloadsManager extends DownloadsLibrary
         );
 
         if (empty($parent)) {
-            return $names;
+            return;
         }
 
         $names[] = $child->getName();
-        return $this->getParentCategoryNamesByChild(
+        $this->getParentCategoryNamesByChild(
             $parent,
             $names
         );

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2448,12 +2448,12 @@ class DownloadsManager extends DownloadsLibrary
             $content =
                 sprintf(
                     $_ARRAYLANG['TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY'],
-                '&bdquo;'.
+                    '&bdquo;'.
                     $this->getCategoryElement($categories['root']) .
                     $this->getCategoryElement($categories['middle']) .
                     $this->getCategoryElement($categories['previous']) .
-                    $this->getCategoryElement($categories['current'])
-                     . '&ldquo;'
+                    $this->getCategoryElement($categories['current']) .
+                    '&ldquo;'
                 );
 
             $this->objTemplate->setVariable(

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2451,12 +2451,10 @@ class DownloadsManager extends DownloadsLibrary
             $content =
                 sprintf(
                     $_ARRAYLANG['TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY'],
-                    '&bdquo;'.
                     $this->getCategoryElement($categories['root']) .
                     $this->getCategoryElement($categories['middle']) .
                     $this->getCategoryElement($categories['previous']) .
-                    $this->getCategoryElement($categories['current']) .
-                    '&ldquo;'
+                    $this->getCategoryElement($categories['current'])
                 );
 
             $this->objTemplate->setVariable(

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2499,8 +2499,13 @@ class DownloadsManager extends DownloadsLibrary
             }
         }
 
-        return '<span title="'.$title.'">' . $text
-            . '</span>';
+        $span = new \Cx\Core\Html\Model\Entity\HtmlElement('span');
+        $span->addChild(
+            new \Cx\Core\Html\Model\Entity\TextElement($text)
+        );
+        $span->setAttribute('title', $title);
+
+        return $span;
     }
 
     /**

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2401,10 +2401,136 @@ class DownloadsManager extends DownloadsLibrary
 
 
         if ($objCategory->getId()) {
-            $this->objTemplate->setVariable('TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY', sprintf($_ARRAYLANG['TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY'], '&bdquo;'.htmlentities($objCategory->getName(), ENT_QUOTES, CONTREXX_CHARSET).'&ldquo;'));
+            $parentNames = $this->getParentCategoryNamesByChild($objCategory);
+
+            $categories = array(
+                'root' => array(),
+                'middle' => array(),
+                'previous' => array(),
+                'current' => array(),
+            );
+
+            foreach($parentNames as $position => $parentName) {
+                if ($position == 0) {
+                    // Position 0 is the "current category"
+                    // Shorten the name after 60 chars
+                    $categories['current']['long'] = $parentName;
+                    $categories['current']['short'] = substr(
+                        $parentName, 0, 60
+                    );
+
+                } else if ($position == 1) {
+                    // Position 1 is the "previous category"
+                    // Shorten the name after 30 chars
+                    $categories['previous']['long'] = $parentName;
+                    $categories['previous']['short'] = substr(
+                        $parentName, 0, 30
+                    );
+
+                } else if ($position == count($parentNames) - 1) {
+                    // The last position is the "root category"
+                    // Shorten the name after 30 chars
+                    $categories['root']['long'] = $parentName;
+                    $categories['root']['short'] = substr(
+                        $parentName, 0, 30
+                    );
+                } else {
+                    // Add the remaining categories to an array
+                    $categories['middle'][] = $parentName;
+                }
+
+            }
+
+            // Flip the array to get the grandparents first
+            $categories['middle'] = array_reverse($categories['middle']);
+
+            $content =
+                sprintf(
+                    $_ARRAYLANG['TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY'],
+                '&bdquo;'.
+                    $this->getCategoryElement($categories['root']) .
+                    $this->getCategoryElement($categories['middle']) .
+                    $this->getCategoryElement($categories['previous']) .
+                    $this->getCategoryElement($categories['current'])
+                     . '&ldquo;'
+                );
+
+            $this->objTemplate->setVariable(
+                'TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY',
+                $content
+            );
         }
     }
 
+    /**
+     * Get a span tag with the category name. If the parameter contains a long
+     * and a short category name, the long name will be added as title
+     * attribute. The short name is used as content for the span tag.
+     *
+     * If the parameter only contains category names, the category names are
+     * listed one below the other in the title attribute. The content of the
+     * span tag consists of three dots.
+     *
+     * @param array $category with long and short category name or only names
+     * @return string a span tag or an empty string
+     */
+    protected function getCategoryElement(array $category) : string
+    {
+        if (empty($category)) {
+            return '';
+        }
+
+        $title = '';
+        $text = '...';
+
+        if (!empty($category['long']) && !empty($category['short'])) {
+            $title = $category['long'];
+            $text = $category['short'];
+
+            if ($category['short'] !== $category['long']) {
+                $text .= '...';
+            }
+
+        } else {
+            foreach ($category as $middle) {
+                $title .= '...' .$middle . "\n";
+            }
+        }
+
+        return '<span title="'.$title.'">' . $text
+            . '</span>';
+    }
+
+    /**
+     * Get the name of the child category and all names of the parent categories
+     *
+     * @param \Cx\Modules\Downloads\Controller\Category $child child category
+     * @param array $names previous category names for recursion
+     * @return array array with all names
+     */
+    protected function getParentCategoryNamesByChild(
+        \Cx\Modules\Downloads\Controller\Category $child,
+        array $names = array()
+    ) : array {
+        if (empty($child->getParentId())) {
+            $names[] = $child->getName();
+            return $names;
+        }
+
+        $parent = \Cx\Modules\Downloads\Controller\Category::getCategory(
+            $child->getParentId()
+        );
+
+        if (empty($parent)) {
+            return $names;
+        }
+
+        $names[] = $child->getName();
+        return $this->getParentCategoryNamesByChild(
+            $parent,
+            $names
+        );
+    }
 
     private function parseCategoryDownloads($objCategory, $downloadOrderBy, $downloadOrderDirection, $downloadLimitOffset, $categoryOrderBy, $categoryOrderDirection, $categoryLimitOffset, $searchTerm)
     {

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2495,7 +2495,7 @@ class DownloadsManager extends DownloadsLibrary
 
         } else {
             foreach ($category as $middle) {
-                $title .= '...' .$middle . "\n";
+                $title .= $middle . "\n";
             }
         }
 

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2518,8 +2518,8 @@ class DownloadsManager extends DownloadsLibrary
         \Cx\Modules\Downloads\Controller\Category $child,
         array &$names
     ) {
+        $names[] = $child->getName();
         if (empty($child->getParentId())) {
-            $names[] = $child->getName();
             return;
         }
 
@@ -2531,7 +2531,6 @@ class DownloadsManager extends DownloadsLibrary
             return;
         }
 
-        $names[] = $child->getName();
         $this->getParentCategoryNamesByChild(
             $parent,
             $names

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -2412,32 +2412,35 @@ class DownloadsManager extends DownloadsLibrary
             );
 
             foreach($parentNames as $position => $parentName) {
-                if ($position == 0) {
-                    // Position 0 is the "current category"
-                    // Shorten the name after 60 chars
-                    $categories['current']['long'] = $parentName;
-                    $categories['current']['short'] = substr(
-                        $parentName, 0, 60
-                    );
-
-                } else if ($position == 1) {
-                    // Position 1 is the "previous category"
-                    // Shorten the name after 30 chars
-                    $categories['previous']['long'] = $parentName;
-                    $categories['previous']['short'] = substr(
-                        $parentName, 0, 30
-                    );
-
-                } else if ($position == count($parentNames) - 1) {
-                    // The last position is the "root category"
-                    // Shorten the name after 30 chars
-                    $categories['root']['long'] = $parentName;
-                    $categories['root']['short'] = substr(
-                        $parentName, 0, 30
-                    );
-                } else {
-                    // Add the remaining categories to an array
-                    $categories['middle'][] = $parentName;
+                switch($position) {
+                    case 0:
+                        // Position 0 is the "current category"
+                        // Shorten the name after 60 chars
+                        $categories['current']['long'] = $parentName;
+                        $categories['current']['short'] = substr(
+                            $parentName, 0, 60
+                        );
+                        break;
+                    case 1:
+                        // Position 1 is the "previous category"
+                        // Shorten the name after 30 chars
+                        $categories['previous']['long'] = $parentName;
+                        $categories['previous']['short'] = substr(
+                            $parentName, 0, 30
+                        );
+                        break;
+                    case count($parentNames) - 1:
+                        // The last position is the "root category"
+                        // Shorten the name after 30 chars
+                        $categories['root']['long'] = $parentName;
+                        $categories['root']['short'] = substr(
+                            $parentName, 0, 30
+                        );
+                        break;
+                    default:
+                        // Add the remaining categories to an array
+                        $categories['middle'][] = $parentName;
+                        break;
                 }
 
             }

--- a/modules/Downloads/View/Template/Backend/module_downloads_categories.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_categories.html
@@ -98,7 +98,7 @@ function downloadsUpdateSortOrder(event,elForm,idMultiAction)
             {TXT_DOWNLOADS_ALL_CATEGORIES}
             {TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY}
             <!-- BEGIN downloads_category_frontend_link -->
-            <a href="{DOWNLOADS_CATEGORY_FRONTEND_URI}" title="{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}" target="_blank" style="background: url(../core/Core/View/Media/icons/blue_arrow_up.png) no-repeat left center; padding: 1px 0 1px 18px; margin: 0 0 0 20px;">{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}</a>
+            <a href="{DOWNLOADS_CATEGORY_FRONTEND_URI}" title="{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}" target="_blank" style="background: url(../core/Core/View/Media/icons/blue_arrow_up.png) no-repeat left center; padding: 1px 0 1px 18px; margin: 0 0 0 20px; float:right;">{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}</a>
             <!-- END downloads_category_frontend_link -->
         </th>
     </tr>

--- a/modules/Downloads/View/Template/Backend/module_downloads_categories.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_categories.html
@@ -64,6 +64,15 @@ function downloadsUpdateSortOrder(event,elForm,idMultiAction)
 // ]]>
 </script>
 
+<style>
+    #downloads_category_form span:after {
+        content: ' / ';
+    }
+    #downloads_category_form span:last-of-type:after {
+        content: '';
+    }
+</style>
+
 <table width="100%" class="adminlist">
     <tr>
         <th>{TXT_DOWNLOADS_FILTER}</th>

--- a/modules/Downloads/View/Template/Backend/module_downloads_categories.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_categories.html
@@ -66,7 +66,7 @@ function downloadsUpdateSortOrder(event,elForm,idMultiAction)
 
 <style>
     #downloads_category_form span:after {
-        content: ' / ';
+        content: ' > ';
     }
     #downloads_category_form span:last-of-type:after {
         content: '';

--- a/modules/Downloads/View/Template/Backend/module_downloads_overview.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_overview.html
@@ -40,7 +40,7 @@ function downloadsCategoryDoAction(action)
 
 <style>
     #downloads_category_form span:after {
-        content: ' / ';
+        content: ' > ';
     }
     #downloads_category_form span:last-of-type:after {
         content: '';

--- a/modules/Downloads/View/Template/Backend/module_downloads_overview.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_overview.html
@@ -38,6 +38,15 @@ function downloadsCategoryDoAction(action)
 /* ]]> */
 </script>
 
+<style>
+    #downloads_category_form span:after {
+        content: ' / ';
+    }
+    #downloads_category_form span:last-of-type:after {
+        content: '';
+    }
+</style>
+
 <table width="100%" class="adminlist">
     <tr>
         <th>{TXT_DOWNLOADS_DOWNLOADS}</th>

--- a/modules/Downloads/View/Template/Backend/module_downloads_overview.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_overview.html
@@ -73,7 +73,7 @@ function downloadsCategoryDoAction(action)
                 {TXT_DOWNLOADS_CATEGORIES}
                 {TXT_DOWNLOADS_CATEGORIES_OF_CATEGORY}
                 <!-- BEGIN downloads_category_frontend_link -->
-                <a href="{DOWNLOADS_CATEGORY_FRONTEND_URI}" title="{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}" target="_blank" style="background: url(../core/Core/View/Media/icons/blue_arrow_up.png) no-repeat left center; padding: 1px 0 1px 18px; margin: 0 0 0 20px;">{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}</a>
+                <a href="{DOWNLOADS_CATEGORY_FRONTEND_URI}" title="{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}" target="_blank" style="background: url(../core/Core/View/Media/icons/blue_arrow_up.png) no-repeat left center; padding: 1px 0 1px 18px; margin: 0 0 0 20px; float: right">{TXT_DOWNLOADS_OPEN_CATEGORY_FRONTEND}</a>
                 <!-- END downloads_category_frontend_link -->
             </th>
         </tr>


### PR DESCRIPTION
Replace the category name in the list of categories with a simple breadcrumb. Now all parent categories are displayed and not just the current category name. 

The root/main category and the previous category are shortened after 30 characters. The current category name after 60 characters. The middle categories are shortened with three dots. If you hover over the category names or dots, the full category name will be displayed.
