### PR TITLE
feat(access): add template block for required fields

### DIFF
--- a/core_modules/Access/Controller/AccessLib.class.php
+++ b/core_modules/Access/Controller/AccessLib.class.php
@@ -465,6 +465,17 @@ class AccessLib
             break;
         }
 
+        if (
+            $objAttribute->isMandatory() &&
+            $this->_objTpl->blockExists(
+                $this->attributeNamePrefix.'_'.$attributeId.'_field_required'
+            )
+        ) {
+            $this->_objTpl->touchBlock(
+                $this->attributeNamePrefix.'_'.$attributeId.'_field_required'
+            );
+        }
+
         if (!$edit && isset($arrPlaceholders['_VALUE']) && $arrPlaceholders['_VALUE'] == '') {
             return false;
         }
@@ -729,6 +740,15 @@ class AccessLib
             $placeholderUC.'_NAME'    => $accountAttributePrefix.$attributeId,
             $placeholderUC.'_ID'        => $accountAttributePrefix.$attributeId
         );
+
+        if ($this->_objTpl->blockExists(
+            $accountAttributePrefix.$attributeId.'_field_required'
+        )
+        ) {
+            $this->_objTpl->touchBlock(
+                $accountAttributePrefix.$attributeId.'_field_required'
+            );
+        }
 
         $arrSettings = \User_Setting::getSettings();
         if (!$arrSettings['use_usernames']['status'] && $attributeId == 'username') {


### PR DESCRIPTION
Adds a new template block to mark required access fields better. Each profile and user attribute has is own template block: 

access_profile_attribute_<attribute_id>_field_required - For profile attributes
access_user_<attribute_id>_field_required - For user attributes 

For profile attributes, a <strong> tag with a star has already been added before this pull-request. This is not very flexible and is below the <input> tag. This leads to unnecessary CSS styles. In this pull request, the feature was not removed for backward compatibility reasons. Please explain what you would like to do next.