### PR TITLE
feat(contentmanager): check if content manager has protected pages

### DIFF
--- a/core/ContentManager/Model/Event/PageEventListener.class.php
+++ b/core/ContentManager/Model/Event/PageEventListener.class.php
@@ -262,5 +262,11 @@ class PageEventListener implements \Cx\Core\Event\Model\Entity\EventListener {
             )
         );
         $search->appendResult($result);
+        $search->setHasProtectedResult(
+            $pageRepo->hasProtectedPages(
+                $search->getTerm(),
+                \Env::get('cx')->getLicense()
+            )
+        );
     }
 }


### PR DESCRIPTION
Based on pull-request #135

Implements the feature from the pull-request #135 to notify the full-text search if it has protected content pages or not. 