### PR TITLE
fix(mailtemplate): use correct link for open multilang templates

### DIFF
--- a/core/MailTemplate/Controller/MailTemplate.class.php
+++ b/core/MailTemplate/Controller/MailTemplate.class.php
@@ -1222,8 +1222,7 @@ die("MailTemplate::init(): Empty section!");
                     : $_CORELANG['TXT_CORE_MAILTEMPLATE_NEW']);
                 $icon =
                     '<a href="'.
-                        CONTREXX_DIRECTORY_INDEX.
-                        "?cmd=$section&amp;act=".$act.
+                        $uri_edit.
                         '&amp;key='.$key.
                         '&amp;userFrontendLangId='.$lang_id.'"'.
                     ' title="'.$title.'">'.


### PR DESCRIPTION
If we want to create a MailTemplate in another language, you only get a white page. This is because you are calling the wrong link. 