### PR TITLE
Take over permissions from parent category

### DIFF
--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -885,6 +885,27 @@ class DownloadsManager extends DownloadsLibrary
             'DOWNLOADS_CATEGORY_APPLY_RECURSIVE_CHECKED' => $objCategory->hasToSetPermissionsRecursive() ? 'checked="checked"' : '',
             'DOWNLOADS_MEDIA_BROWSER_BUTTON'             => self::getMediaBrowserButton(null, 'filebrowser')
         ));
+
+        if (
+            !$objCategory->getId() &&
+            $this->objTemplate->blockExists(
+                'downloads_category_take_over_parent_permissions'
+            )
+        ) {
+            $this->objTemplate->setVariable(array(
+                'TXT_DOWNLOADS_CATEGORY_TAKE_OVER_PARENT_PERMISSION' => $_ARRAYLANG[
+                    'TXT_DOWNLOADS_CATEGORY_TAKE_OVER_PARENT_PERMISSION'
+                ]
+            ));
+            $this->objTemplate->touchBlock(
+                'downloads_category_take_over_parent_permissions'
+            );
+        } else {
+            $this->objTemplate->hideBlock(
+                'downloads_category_take_over_parent_permissions'
+            );
+        }
+
         return true;
     }
 

--- a/modules/Downloads/Controller/DownloadsManager.class.php
+++ b/modules/Downloads/Controller/DownloadsManager.class.php
@@ -691,7 +691,24 @@ class DownloadsManager extends DownloadsLibrary
             }
 
             $objCategory->setPermissionsRecursive(!empty($_POST['downloads_category_apply_recursive']));
-            $objCategory->setPermissions($arrCategoryPermissions);
+            if (
+                $_POST['downloads_category_take_over_parent_permissions'] &&
+                $objCategory->getParentId() &&
+                !$objCategory->getId()
+            ) {
+                $parent = \Cx\Modules\Downloads\Controller\Category::getCategory(
+                    $objCategory->getParentId()
+                );
+                $parentPermissions = $parent->getPermissions();
+                foreach ($this->arrPermissionTypes as $protectionType) {
+                    unset($parentPermissions[$protectionType]['associated_groups']);
+                    unset($parentPermissions[$protectionType]['not_associated_groups']);
+                }
+
+                $objCategory->setPermissions($parentPermissions);
+            } else {
+                $objCategory->setPermissions($arrCategoryPermissions);
+            }
 
             if ($status && $objCategory->store()) {
                 $this->parentCategoryId = $objCategory->getParentId();

--- a/modules/Downloads/View/Template/Backend/module_downloads_category_modify.html
+++ b/modules/Downloads/View/Template/Backend/module_downloads_category_modify.html
@@ -1,6 +1,41 @@
 <!-- start module_downloads_modify_category.html -->
 <script type="text/javascript">
 // <![CDATA[
+    document.addEventListener("DOMContentLoaded", function(event) {
+        const select = document.querySelector('select[name="downloads_category_parent_id"]');
+        select.addEventListener('change', () => {
+            loadPermission(select);
+        });
+        loadPermission(select);
+    });
+    function loadPermission(select) {
+        const checkbox = document.getElementById('downloads_category_take_over_parent_permissions');
+        if (!checkbox) {
+            return;
+        }
+        if (select.selectedIndex) {
+            checkbox.checked = true;
+            checkbox.parentElement.parentElement.parentElement.classList.remove('hide-permission');
+            togglePermissions();
+        } else {
+            checkbox.checked = false;
+            checkbox.parentElement.parentElement.parentElement.classList.add('hide-permission');
+            togglePermissions();
+        }
+    }
+
+    function togglePermissions() {
+        document.querySelectorAll(
+            '#categoryPermissions > :nth-child(n+2), #categoryPermissions > table:first-child tr:nth-child(n+2)'
+        ).forEach((tr) => {
+            if (document.getElementById('downloads_category_take_over_parent_permissions').checked) {
+                tr.classList.add('hide-permission');
+            } else {
+                tr.classList.remove('hide-permission');
+            }
+        });
+    }
+
     function downloadsSyncNameFields(value, type, name) {
         for (i=0; i < document.getElementById('downloads_category_form').getElementsByTagName(type).length;i++) {
             if (typeof(document.getElementById('downloads_category_form').getElementsByTagName(type)[i].name) != 'undefined'
@@ -193,8 +228,16 @@
             //document.getElementById('downloads_category_image_preview').style.height = thumb_height;
         }
     }
+
+
 // ]]>
 </script>
+<style>
+    /* !important is necessary to overwrite the inline-styles */
+    .hide-permission {
+        display: none !important;
+    }
+</style>
 
 <ul id="tabmenu">
     <li><a id="downloadsTab_categoryGeneral" class="active" href="javascript:void(0)" onclick="selectTab('categoryGeneral')" title="{TXT_DOWNLOADS_GENERAL}">{TXT_DOWNLOADS_GENERAL}</a></li>
@@ -331,6 +374,22 @@
                 </tr>
             </thead>
             <tbody style="vertical-align:top;">
+                <!-- BEGIN downloads_category_take_over_parent_permissions -->
+                <tr class="row1 hide-permission">
+                    <td>
+                        <label for="downloads_category_take_over_parent_permissions">
+                            <input
+                                    type="checkbox"
+                                    name="downloads_category_take_over_parent_permissions"
+                                    value="1"
+                                    id="downloads_category_take_over_parent_permissions"
+                                    onclick="togglePermissions()"
+                            />
+                            {TXT_DOWNLOADS_CATEGORY_TAKE_OVER_PARENT_PERMISSION}
+                        </label>
+                    </td>
+                </tr>
+                <!-- END downloads_category_take_over_parent_permissions -->
                 <tr class="row3">
                     <td style="font-weight:bold;">{TXT_DOWNLOADS_VIEW_CONTENT}</td>
                 </tr>

--- a/modules/Downloads/lang/de/backend.php
+++ b/modules/Downloads/lang/de/backend.php
@@ -204,6 +204,7 @@ $_ARRAYLANG['TXT_DOWNLOADS_ADD_MAIN_CATEGORY_PROHIBITED'] = "Sie sind nicht bere
 $_ARRAYLANG['TXT_DOWNLOADS_ADD_NEW_DOWNLOAD'] = "Neuen Download hinzufügen";
 $_ARRAYLANG['TXT_DOWNLOADS_ADD_SUBCATEGORY_TO_CATEGORY_PROHIBITED'] = "Sie sind nicht berechtigt in der Kategorie <strong>%s</strong> eine neue Unterkategorie anzulegen!";
 $_ARRAYLANG['TXT_DOWNLOADS_APPLY_PERMISSIONS_RECURSIVEJ'] = "Diese Berechtigungen für alle Unterkategorien übernehmen.";
+$_ARRAYLANG['TXT_DOWNLOADS_CATEGORY_TAKE_OVER_PARENT_PERMISSION'] = ' Zugriffsberechtigungen der übergeordneten Kategorie übernehmen.';
 $_ARRAYLANG['TXT_DOWNLOADS_ASSIGNED_CATEGORIES'] = "Zugewiesene Kategorien";
 $_ARRAYLANG['TXT_DOWNLOADS_AVAILABLE_CATEGORIES'] = "Verfügbare Kategorien";
 $_ARRAYLANG['TXT_DOWNLOADS_BYTES'] = "Bytes";

--- a/modules/Downloads/lang/en/backend.php
+++ b/modules/Downloads/lang/en/backend.php
@@ -204,6 +204,7 @@ $_ARRAYLANG['TXT_DOWNLOADS_ADD_MAIN_CATEGORY_PROHIBITED'] = "You do not have the
 $_ARRAYLANG['TXT_DOWNLOADS_ADD_NEW_DOWNLOAD'] = "Add new download";
 $_ARRAYLANG['TXT_DOWNLOADS_ADD_SUBCATEGORY_TO_CATEGORY_PROHIBITED'] = "You do not have the rights to create sub-directories in <strong>%s</strong>.";
 $_ARRAYLANG['TXT_DOWNLOADS_APPLY_PERMISSIONS_RECURSIVEJ'] = "Apply permissions for all sub-categories";
+$_ARRAYLANG['TXT_DOWNLOADS_CATEGORY_TAKE_OVER_PARENT_PERMISSION'] = ' Use the access permissions of the parent category.';
 $_ARRAYLANG['TXT_DOWNLOADS_ASSIGNED_CATEGORIES'] = "Assigned categories";
 $_ARRAYLANG['TXT_DOWNLOADS_AVAILABLE_CATEGORIES'] = "Available categories";
 $_ARRAYLANG['TXT_DOWNLOADS_BYTES'] = "Bytes";


### PR DESCRIPTION
In the create categories view, adds the option to to take over permissions from
the parent category. This is activated as soon as a parent category is selected.
If this option is activated, the individual permissions from the new category
are hidden. If the option is deactivated, the areas are displayed again and the
new category's own permissions are taken over.