### PR TITLE
Implement file extension icons

### DIFF
--- a/core_modules/Media/Controller/MediaLibrary.class.php
+++ b/core_modules/Media/Controller/MediaLibrary.class.php
@@ -716,6 +716,8 @@ class MediaLibrary
      */
     public static function _getIcon($file, $fileType = null)
     {
+        $cx = \Cx\Core\Core\Controller\Cx::instanciate();
+
         $icon = '';
         if (isset($fileType)) {
             $icon = strtoupper($fileType);
@@ -724,6 +726,15 @@ class MediaLibrary
             if (isset($info['extension'])) {
                 $icon = strtoupper($info['extension']);
             }
+        }
+
+        $extensionIcon = 'ExtensionIcons/'.strtolower($icon);
+        if (
+            file_exists($cx->getClassLoader()->getFilePath(
+                self::_getIconPath().$extensionIcon.'.png'
+            ))
+        ) {
+            return $extensionIcon;
         }
 
         $arrImageExt        = array('JPEG', 'JPG', 'TIFF', 'GIF', 'BMP', 'PNG');


### PR DESCRIPTION
If an icon for a file extension is found, it will be used instead of the file
type icon.

Extension icons can be stored in the folder core_modules/Media/View/Media/ExtensionIcons/.

