### PR TITLE
Implement protected search result block in downloads

### DIFF
--- a/modules/Downloads/Controller/ComponentController.class.php
+++ b/modules/Downloads/Controller/ComponentController.class.php
@@ -292,11 +292,12 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
 
     /**
      * Select all protected downloads, if downloads were found return true
+     * Filtered by a searchterm
      *
-     * @param $searchTerm $searchTerm The keyword to search by
+     * @param string $searchTerm The keyword to search by
      * @return bool if protected downloads exist
      */
-    public function hasProtectedDownloads($searchTerm)
+    public function hasProtectedDownloadsForSearch($searchTerm)
     {
         $downloadLibrary = new DownloadsLibrary();
         $config = $downloadLibrary->getSettings();
@@ -321,19 +322,7 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
             return false;
         }
 
-        if ($download->loadDownloads(
-            $filter,
-            $searchTerm,
-            null,
-            null,
-            null,
-            null,
-            $config['list_downloads_current_lang']
-        )) {
-            return true;
-        }
-
-        return false;
+        return $download->hasProtectedDownloads($filter, $searchTerm);
     }
 
     /**

--- a/modules/Downloads/Controller/ComponentController.class.php
+++ b/modules/Downloads/Controller/ComponentController.class.php
@@ -291,6 +291,52 @@ class ComponentController extends \Cx\Core\Core\Model\Entity\SystemComponentCont
     }
 
     /**
+     * Select all protected downloads, if downloads were found return true
+     *
+     * @param $searchTerm $searchTerm The keyword to search by
+     * @return bool if protected downloads exist
+     */
+    public function hasProtectedDownloads($searchTerm)
+    {
+        $downloadLibrary = new DownloadsLibrary();
+        $config = $downloadLibrary->getSettings();
+        $download = new Download($config);
+
+        // check for valid published application page
+        $filter = null;
+        try {
+            $arrCategoryIds = $this->getCategoryFilterForSearchComponent();
+
+            // set category filter if we have to restrict search by
+            // any category IDs
+            if ($arrCategoryIds) {
+                $filter = array('category_id' => $arrCategoryIds);
+            }
+            // Search if protected downloads exists
+            $filter['access_id'] = array(
+                '!=' => 0
+            );
+            $filter['visibility'] = 0;
+        } catch (DownloadsInternalException $e) {
+            return false;
+        }
+
+        if ($download->loadDownloads(
+            $filter,
+            $searchTerm,
+            null,
+            null,
+            null,
+            null,
+            $config['list_downloads_current_lang']
+        )) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Get published category IDs (as application pages)
      *
      *

--- a/modules/Downloads/Controller/Download.class.php
+++ b/modules/Downloads/Controller/Download.class.php
@@ -1463,6 +1463,29 @@ class Download {
         return $arrIds;
     }
 
+    /**
+     * Select all protected downloads, if downloads were found return true
+     *
+     * @param array $filter To filter downloads
+     * @param string $searchTerm The keyword to search by
+     * @return bool if protected downloads exist
+     */
+    public function hasProtectedDownloads($filter, $searchTerm)
+    {
+        if ($this->loadDownloads(
+            $filter,
+            $searchTerm,
+            null,
+            null,
+            null,
+            null,
+            $this->config['list_downloads_current_lang']
+        )) {
+            return true;
+        }
+
+        return false;
+    }
 
     public function incrementDownloadCount()
     {

--- a/modules/Downloads/Controller/Download.class.php
+++ b/modules/Downloads/Controller/Download.class.php
@@ -1060,11 +1060,20 @@ class Download {
                 $arrConditions[] = 'tblD.`is_active` = 1';
             }
             if (!\Permission::checkAccess(143, 'static', true)) {
-                $arrConditions[] = 'tblD.`visibility` = 1'.(
+                $visibility = '';
+                $or = ' ';
+                if (!isset($arrFilter['visibility'])) {
+                    $visibility = 'tblD.`visibility` = 1';
+                    $or = ' OR ';
+                }
+                $conditionStr = $visibility.(
                     $objFWUser->objUser->login() ?
-                    ' OR tblD.`owner_id` = '.$objFWUser->objUser->getId()
+                        $or.'tblD.`owner_id` = '.$objFWUser->objUser->getId()
                     .(count($objFWUser->objUser->getDynamicPermissionIds()) ? ' OR tblD.`access_id` IN ('.implode(', ', $objFWUser->objUser->getDynamicPermissionIds()).')' : '')
                     : '');
+                if (!empty($conditionStr)) {
+                    $arrConditions[] = $conditionStr;
+                }
             }
 
 
@@ -1220,7 +1229,7 @@ class Download {
         );
 
         $arrComparisonOperators = array(
-            'int'       => array('=','<','>', '<=', '>='),
+            'int'       => array('!=', '=','<','>', '<=', '>='),
             'string'    => array('!=','<','>', 'REGEXP')
         );
         $arrDefaultComparisonOperator = array(

--- a/modules/Downloads/Model/Event/DownloadsEventListener.class.php
+++ b/modules/Downloads/Model/Event/DownloadsEventListener.class.php
@@ -62,7 +62,7 @@ class DownloadsEventListener extends DefaultEventListener
         );
         $search->appendResult($result);
         $search->setHasProtectedResult(
-            $this->getComponent('Downloads')->hasProtectedDownloads(
+            $this->getComponent('Downloads')->hasProtectedDownloadsForSearch(
                 $search->getTerm()
             )
         );

--- a/modules/Downloads/Model/Event/DownloadsEventListener.class.php
+++ b/modules/Downloads/Model/Event/DownloadsEventListener.class.php
@@ -61,6 +61,11 @@ class DownloadsEventListener extends DefaultEventListener
             )
         );
         $search->appendResult($result);
+        $search->setHasProtectedResult(
+            $this->getComponent('Downloads')->hasProtectedDownloads(
+                $search->getTerm()
+            )
+        );
     }
 
     public function mediasourceLoad(


### PR DESCRIPTION
Based on pull-request #135

Implements the feature from the pull-request #135 to notify the full-text search if it has protected downloads or not.