### PR TITLE
Fix getJson()

### DIFF
--- a/core/Json/JsonData.class.php
+++ b/core/Json/JsonData.class.php
@@ -387,6 +387,7 @@ class JsonData {
             $userAgent = $headers['user-agent'] . ' ' . \DBG::getLogHash();
             $request->setHeader('user-agent', $userAgent);
         }
+        $request->setConfig('timeout', 20);
 
         if (!empty($httpAuth)) {
             switch($httpAuth['httpAuthMethod']) {

--- a/core/Json/JsonData.class.php
+++ b/core/Json/JsonData.class.php
@@ -411,7 +411,9 @@ class JsonData {
                 'Content-Type',
                 'application/json'
             );
-            $request->setBody(json_encode($data));
+            if (count($data)) {
+                $request->setBody(json_encode($data));
+            }
         } else {
             foreach ($data as $name=>$value) {
                 $request->addPostParameter($name, $value);

--- a/core/Json/JsonData.class.php
+++ b/core/Json/JsonData.class.php
@@ -377,7 +377,11 @@ class JsonData {
         $files = array(),
         $sendJson = false
     ) {
-        $request = new \HTTP_Request2($url, \HTTP_Request2::METHOD_POST);
+        if (count($data)) {
+            $request = new \HTTP_Request2($url, \HTTP_Request2::METHOD_POST);
+        } else{
+            $request = new \HTTP_Request2($url, \HTTP_Request2::METHOD_GET);
+        }
         $headers = $request->getHeaders();
         if (isset($headers['user-agent'])) {
             $userAgent = $headers['user-agent'] . ' ' . \DBG::getLogHash();

--- a/core/Json/JsonData.class.php
+++ b/core/Json/JsonData.class.php
@@ -367,6 +367,7 @@ class JsonData {
      * </pre>
      * @param array $files Key is the POST field name, value is the file path
      * @param boolean $sendJson Whether to encode data as JSON, default false
+     * @param int $timeout Max. time in seconds the request may take. 0 for no timeout
      * @return stdClass|boolean Decoded JSON on success, false otherwise
      */
     public function getJson(
@@ -375,7 +376,8 @@ class JsonData {
         $certificateFile = '',
         $httpAuth=array(),
         $files = array(),
-        $sendJson = false
+        $sendJson = false,
+        $timeout = 0
     ) {
         if (count($data)) {
             $request = new \HTTP_Request2($url, \HTTP_Request2::METHOD_POST);
@@ -387,7 +389,9 @@ class JsonData {
             $userAgent = $headers['user-agent'] . ' ' . \DBG::getLogHash();
             $request->setHeader('user-agent', $userAgent);
         }
-        $request->setConfig('timeout', 20);
+        if ($timeout) {
+            $request->setConfig('timeout', $timeout);
+        }
 
         if (!empty($httpAuth)) {
             switch($httpAuth['httpAuthMethod']) {


### PR DESCRIPTION
getJson() does not work well to make real-live requests to an API because it can only do POST requests.