### PR TITLE
fix(view): show messages automatically

### DIFF
--- a/lib/javascript/cx/contrexxJs.js
+++ b/lib/javascript/cx/contrexxJs.js
@@ -420,7 +420,11 @@ var ContrexxJs = function(theOptions) {
                         options.preError(jqXHR, textStatus, data.message);
                     }
                     if (cx.ui && options.showMessage) {
-                        cx.ui.messages.add(cx.variables.get("operationFailed", "contrexx/lang"), "error");
+                        if (data.message != "") {
+                            cx.ui.messages.add(data.message, "error");
+                        } else {
+                            cx.ui.messages.add(cx.variables.get("operationFailed", "contrexx/lang"), "error");
+                        }
                     }
                     if (options.postError) {
                         options.postError(jqXHR, textStatus, data.message);
@@ -431,7 +435,11 @@ var ContrexxJs = function(theOptions) {
                     options.preSuccess(data, textStatus, jqXHR);
                 }
                 if (cx.ui && options.showMessage) {
-                    cx.ui.messages.add(cx.variables.get("operationSuccessful", "contrexx/lang"), "success");
+                    if (data.message != "") {
+                        cx.ui.messages.add(data.message, "success");
+                    } else {
+                        cx.ui.messages.add(cx.variables.get("operationSuccessful", "contrexx/lang"), "success");
+                    }
                 }
                 if (options.postSuccess) {
                     options.postSuccess(data, textStatus, jqXHR);


### PR DESCRIPTION
This was the intended way when this code was written. This code is about 2 years old but never made it to master.

About backwards compatibility of this PR:
The only usage where "showMessage" is set to true I could find is in core/Html/View/Script/Backend.js for the VG's "status" function. Since the JSON endpoint does not return any message on success this leads to no change in the success case.
The error case handled by core/Html/View/Script/Backend.js handles non-200 status codes (HTTP layer errors). The new code handling errors in lib/javascript/cx/contrexxJs.js handles application level errors (HTTP status 200, data.status != "success").