### PR TITLE
fix(core): let global cx find local cx within a symlink

### DIFF
--- a/cx
+++ b/cx
@@ -1925,7 +1925,7 @@ function isPortFree {
 #####################
 
 # this finds "cx" in current pwd or above
-path="$(pwd)"
+path="$(pwd -P)"
 result=""
 found=false
 while [[ $path != / ]];


### PR DESCRIPTION
If you follow a symlink from outside an environment to within the environment, the global cx won't be able to find the correct local cx.

This fixes this problem.

Grüessli